### PR TITLE
Added text alignment of label within text painter

### DIFF
--- a/lib/src/common/label.dart
+++ b/lib/src/common/label.dart
@@ -95,6 +95,7 @@ Figure renderLabel(
   final painter = TextPainter(
     text: TextSpan(text: label.text, style: label.style.style),
     textDirection: TextDirection.ltr,
+    textAlign: TextAlign.center,
   );
   painter.layout();
 


### PR DESCRIPTION
Rationale for merge request:
I was trying to center a multi-character label on the horizontal axis tick. If I forego alignment we see the following
<img width="104" alt="Screen Shot 2022-01-22 at 3 50 00 PM" src="https://user-images.githubusercontent.com/16787847/150656591-f805d7e5-40ba-4b35-bf29-ef1ec18cdc02.png">
  
Using the center text alignment however fixes this slight off-centeredness
<img width="136" alt="Screen Shot 2022-01-22 at 3 50 13 PM" src="https://user-images.githubusercontent.com/16787847/150656611-348498aa-cfe5-469d-affa-55c2f8ef6dda.png">

