### PR TITLE
fix: remove tooltip on exit chart area

### DIFF
--- a/example/lib/pages/interval.dart
+++ b/example/lib/pages/interval.dart
@@ -78,7 +78,13 @@ class IntervalPage extends StatelessWidget {
                     Defaults.horizontalAxis,
                     Defaults.verticalAxis,
                   ],
-                  selections: {'tap': PointSelection(dim: Dim.x)},
+                  selections: {
+                    'hover': PointSelection(
+                      dim: Dim.x,
+                      on: {GestureType.hover},
+                      clear: {GestureType.mouseExit},
+                    )
+                  },
                   tooltip: TooltipGuide(),
                   crosshair: CrosshairGuide(),
                 ),

--- a/lib/src/chart/chart.dart
+++ b/lib/src/chart/chart.dart
@@ -1,21 +1,22 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:graphic/src/chart/size.dart';
-import 'package:graphic/src/util/collection.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:graphic/src/chart/size.dart';
+import 'package:graphic/src/coord/coord.dart';
 import 'package:graphic/src/coord/polar.dart';
 import 'package:graphic/src/coord/rect.dart';
 import 'package:graphic/src/data/data_set.dart';
+import 'package:graphic/src/geom/element.dart';
+import 'package:graphic/src/guide/annotation/annotation.dart';
+import 'package:graphic/src/guide/axis/axis.dart';
 import 'package:graphic/src/guide/interaction/crosshair.dart';
 import 'package:graphic/src/guide/interaction/tooltip.dart';
 import 'package:graphic/src/interaction/gesture.dart';
 import 'package:graphic/src/interaction/selection/selection.dart';
-import 'package:graphic/src/guide/annotation/annotation.dart';
-import 'package:graphic/src/guide/axis/axis.dart';
-import 'package:graphic/src/coord/coord.dart';
-import 'package:graphic/src/geom/element.dart';
+import 'package:graphic/src/util/collection.dart';
 import 'package:graphic/src/variable/transform/transform.dart';
 import 'package:graphic/src/variable/variable.dart';
 
@@ -213,6 +214,19 @@ class _ChartState<D> extends State<Chart<D>> {
   /// Details of previous scale update.
   ScaleUpdateDetails? gestureScaleDetail;
 
+  /// Keep track if there is a mouse connected.
+  late bool _mouseIsConnected;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _mouseIsConnected = RendererBinding.instance!.mouseTracker.mouseIsConnected;
+
+    RendererBinding.instance!.mouseTracker
+        .addListener(_handleMouseTrackerChange);
+  }
+
   /// Asks the chart state to trigger a repaint.
   void repaint() {
     setState(() {});
@@ -231,468 +245,512 @@ class _ChartState<D> extends State<Chart<D>> {
     }
   }
 
+  // Forces a rebuild if a mouse has been added or removed.
+  void _handleMouseTrackerChange() {
+    if (!mounted) {
+      return;
+    }
+
+    final mouseIsConnected =
+        RendererBinding.instance!.mouseTracker.mouseIsConnected;
+    if (mouseIsConnected != _mouseIsConnected) {
+      setState(() {
+        _mouseIsConnected = mouseIsConnected;
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return CustomSingleChildLayout(
-      delegate: _ChartLayoutDelegate<D>(this),
-      // Listener for hover and scroll.
-      child: Listener(
-        child: GestureDetector(
-          child: CustomPaint(
-            // Make sure the Listener and the GestureDetector inflate the container.
-            size: Size.infinite,
-            painter: _ChartPainter<D>(this),
-          ),
-          onDoubleTap: () {
-            view!.gesture(Gesture(
-              GestureType.doubleTap,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onDoubleTapCancel: () {
-            view!.gesture(Gesture(
-              GestureType.doubleTapCancel,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onDoubleTapDown: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.doubleTapDown,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onForcePressEnd: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.forcePressEnd,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onForcePressPeak: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.forcePressPeak,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onForcePressStart: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.forcePressStart,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onForcePressUpdate: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.forcePressUpdate,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onLongPress: () {
-            view!.gesture(Gesture(
-              GestureType.longPress,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onLongPressCancel: () {
-            view!.gesture(Gesture(
-              GestureType.longPressCancel,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onLongPressDown: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.longPressDown,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onLongPressEnd: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            gestureLocalMoveStart = null;
-            view!.gesture(Gesture(
-              GestureType.longPressEnd,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onLongPressMoveUpdate: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.longPressMoveUpdate,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-              localMoveStart: gestureLocalMoveStart,
-            ));
-          },
-          onLongPressStart: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            gestureLocalMoveStart = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.longPressStart,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onLongPressUp: () {
-            view!.gesture(Gesture(
-              GestureType.longPressUp,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onScaleEnd: (detail) {
-            gestureLocalMoveStart = null;
-            gestureScaleDetail = null;
-            view!.gesture(Gesture(
-              GestureType.scaleEnd,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onScaleStart: (detail) {
-            gestureLocalPosition = detail.localFocalPoint;
-            gestureLocalMoveStart = detail.localFocalPoint;
-            // Mock a ScaleUpdateDetails so that the first scale update will have
-            // a preScaleDetail.
-            gestureScaleDetail = ScaleUpdateDetails(
-              focalPoint: detail.focalPoint,
-              localFocalPoint: detail.localFocalPoint,
-              pointerCount: detail.pointerCount,
-            );
-            view!.gesture(Gesture(
-              GestureType.scaleStart,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onScaleUpdate: (detail) {
-            gestureLocalPosition = detail.localFocalPoint;
-            view!.gesture(Gesture(
-              GestureType.scaleUpdate,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-              localMoveStart: gestureLocalMoveStart,
-              preScaleDetail: gestureScaleDetail,
-            ));
-            gestureScaleDetail = detail;
-          },
-          onSecondaryLongPress: () {
-            view!.gesture(Gesture(
-              GestureType.secondaryLongPress,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onSecondaryLongPressCancel: () {
-            view!.gesture(Gesture(
-              GestureType.secondaryLongPressCancel,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onSecondaryLongPressDown: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.secondaryLongPressDown,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onSecondaryLongPressEnd: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            gestureLocalMoveStart = null;
-            view!.gesture(Gesture(
-              GestureType.secondaryLongPressEnd,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onSecondaryLongPressMoveUpdate: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.secondaryLongPressMoveUpdate,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-              localMoveStart: gestureLocalMoveStart,
-            ));
-          },
-          onSecondaryLongPressStart: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            gestureLocalMoveStart = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.secondaryLongPressStart,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onSecondaryLongPressUp: () {
-            view!.gesture(Gesture(
-              GestureType.secondaryLongPressUp,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onSecondaryTap: () {
-            view!.gesture(Gesture(
-              GestureType.secondaryTap,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onSecondaryTapCancel: () {
-            view!.gesture(Gesture(
-              GestureType.secondaryTapCancel,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onSecondaryTapDown: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.secondaryTapDown,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onSecondaryTapUp: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.secondaryTapUp,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onTap: () {
-            view!.gesture(Gesture(
-              GestureType.tap,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onTapCancel: () {
-            view!.gesture(Gesture(
-              GestureType.tapCancel,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onTapDown: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.tapDown,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onTapUp: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.tapUp,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onTertiaryLongPress: () {
-            view!.gesture(Gesture(
-              GestureType.tertiaryLongPress,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onTertiaryLongPressCancel: () {
-            view!.gesture(Gesture(
-              GestureType.tertiaryLongPressCancel,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onTertiaryLongPressDown: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.tertiaryLongPressDown,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onTertiaryLongPressEnd: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            gestureLocalMoveStart = null;
-            view!.gesture(Gesture(
-              GestureType.tertiaryLongPressEnd,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onTertiaryLongPressMoveUpdate: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.tertiaryLongPressMoveUpdate,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-              localMoveStart: gestureLocalMoveStart,
-            ));
-          },
-          onTertiaryLongPressStart: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            gestureLocalMoveStart = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.tertiaryLongPressStart,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onTertiaryLongPressUp: () {
-            view!.gesture(Gesture(
-              GestureType.tertiaryLongPressUp,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onTertiaryTapCancel: () {
-            view!.gesture(Gesture(
-              GestureType.tertiaryTapCancel,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              null,
-            ));
-          },
-          onTertiaryTapDown: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.tertiaryTapDown,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
-          onTertiaryTapUp: (detail) {
-            gestureLocalPosition = detail.localPosition;
-            view!.gesture(Gesture(
-              GestureType.tertiaryTapUp,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              detail,
-            ));
-          },
+    Widget child = Listener(
+      child: GestureDetector(
+        child: CustomPaint(
+          // Make sure the Listener and the GestureDetector inflate the container.
+          size: Size.infinite,
+          painter: _ChartPainter<D>(this),
         ),
-        onPointerHover: (event) {
-          gestureKind = event.kind;
-          gestureLocalPosition = event.localPosition;
+        onDoubleTap: () {
           view!.gesture(Gesture(
-            GestureType.hover,
+            GestureType.doubleTap,
             gestureKind,
             gestureLocalPosition,
             size,
             null,
           ));
         },
-        onPointerSignal: (event) {
-          gestureLocalPosition = event.localPosition;
-          if (event is PointerScrollEvent) {
-            view!.gesture(Gesture(
-              GestureType.scroll,
-              gestureKind,
-              gestureLocalPosition,
-              size,
-              event.scrollDelta,
-            ));
-          }
+        onDoubleTapCancel: () {
+          view!.gesture(Gesture(
+            GestureType.doubleTapCancel,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onDoubleTapDown: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.doubleTapDown,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onForcePressEnd: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.forcePressEnd,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onForcePressPeak: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.forcePressPeak,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onForcePressStart: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.forcePressStart,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onForcePressUpdate: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.forcePressUpdate,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onLongPress: () {
+          view!.gesture(Gesture(
+            GestureType.longPress,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onLongPressCancel: () {
+          view!.gesture(Gesture(
+            GestureType.longPressCancel,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onLongPressDown: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.longPressDown,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onLongPressEnd: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          gestureLocalMoveStart = null;
+          view!.gesture(Gesture(
+            GestureType.longPressEnd,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onLongPressMoveUpdate: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.longPressMoveUpdate,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+            localMoveStart: gestureLocalMoveStart,
+          ));
+        },
+        onLongPressStart: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          gestureLocalMoveStart = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.longPressStart,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onLongPressUp: () {
+          view!.gesture(Gesture(
+            GestureType.longPressUp,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onScaleEnd: (detail) {
+          gestureLocalMoveStart = null;
+          gestureScaleDetail = null;
+          view!.gesture(Gesture(
+            GestureType.scaleEnd,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onScaleStart: (detail) {
+          gestureLocalPosition = detail.localFocalPoint;
+          gestureLocalMoveStart = detail.localFocalPoint;
+          // Mock a ScaleUpdateDetails so that the first scale update will have
+          // a preScaleDetail.
+          gestureScaleDetail = ScaleUpdateDetails(
+            focalPoint: detail.focalPoint,
+            localFocalPoint: detail.localFocalPoint,
+            pointerCount: detail.pointerCount,
+          );
+          view!.gesture(Gesture(
+            GestureType.scaleStart,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onScaleUpdate: (detail) {
+          gestureLocalPosition = detail.localFocalPoint;
+          view!.gesture(Gesture(
+            GestureType.scaleUpdate,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+            localMoveStart: gestureLocalMoveStart,
+            preScaleDetail: gestureScaleDetail,
+          ));
+          gestureScaleDetail = detail;
+        },
+        onSecondaryLongPress: () {
+          view!.gesture(Gesture(
+            GestureType.secondaryLongPress,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onSecondaryLongPressCancel: () {
+          view!.gesture(Gesture(
+            GestureType.secondaryLongPressCancel,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onSecondaryLongPressDown: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.secondaryLongPressDown,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onSecondaryLongPressEnd: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          gestureLocalMoveStart = null;
+          view!.gesture(Gesture(
+            GestureType.secondaryLongPressEnd,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onSecondaryLongPressMoveUpdate: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.secondaryLongPressMoveUpdate,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+            localMoveStart: gestureLocalMoveStart,
+          ));
+        },
+        onSecondaryLongPressStart: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          gestureLocalMoveStart = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.secondaryLongPressStart,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onSecondaryLongPressUp: () {
+          view!.gesture(Gesture(
+            GestureType.secondaryLongPressUp,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onSecondaryTap: () {
+          view!.gesture(Gesture(
+            GestureType.secondaryTap,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onSecondaryTapCancel: () {
+          view!.gesture(Gesture(
+            GestureType.secondaryTapCancel,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onSecondaryTapDown: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.secondaryTapDown,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onSecondaryTapUp: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.secondaryTapUp,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onTap: () {
+          view!.gesture(Gesture(
+            GestureType.tap,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onTapCancel: () {
+          view!.gesture(Gesture(
+            GestureType.tapCancel,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onTapDown: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.tapDown,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onTapUp: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.tapUp,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onTertiaryLongPress: () {
+          view!.gesture(Gesture(
+            GestureType.tertiaryLongPress,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onTertiaryLongPressCancel: () {
+          view!.gesture(Gesture(
+            GestureType.tertiaryLongPressCancel,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onTertiaryLongPressDown: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.tertiaryLongPressDown,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onTertiaryLongPressEnd: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          gestureLocalMoveStart = null;
+          view!.gesture(Gesture(
+            GestureType.tertiaryLongPressEnd,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onTertiaryLongPressMoveUpdate: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.tertiaryLongPressMoveUpdate,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+            localMoveStart: gestureLocalMoveStart,
+          ));
+        },
+        onTertiaryLongPressStart: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          gestureLocalMoveStart = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.tertiaryLongPressStart,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onTertiaryLongPressUp: () {
+          view!.gesture(Gesture(
+            GestureType.tertiaryLongPressUp,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onTertiaryTapCancel: () {
+          view!.gesture(Gesture(
+            GestureType.tertiaryTapCancel,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onTertiaryTapDown: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.tertiaryTapDown,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
+        },
+        onTertiaryTapUp: (detail) {
+          gestureLocalPosition = detail.localPosition;
+          view!.gesture(Gesture(
+            GestureType.tertiaryTapUp,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            detail,
+          ));
         },
       ),
+      onPointerHover: (event) {
+        gestureKind = event.kind;
+        gestureLocalPosition = event.localPosition;
+        view!.gesture(Gesture(
+          GestureType.hover,
+          gestureKind,
+          gestureLocalPosition,
+          size,
+          null,
+        ));
+      },
+      onPointerSignal: (event) {
+        gestureLocalPosition = event.localPosition;
+        if (event is PointerScrollEvent) {
+          view!.gesture(Gesture(
+            GestureType.scroll,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            event.scrollDelta,
+          ));
+        }
+      },
+    );
+
+    // If there is a connected mouse, keep track of onEnter and onExit events.
+    if (_mouseIsConnected) {
+      child = MouseRegion(
+        child: child,
+        onEnter: (event) {
+          gestureKind = event.kind;
+          gestureLocalPosition = event.localPosition;
+          view!.gesture(Gesture(
+            GestureType.mouseEnter,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+        onExit: (event) {
+          gestureKind = event.kind;
+          gestureLocalPosition = event.localPosition;
+          view!.gesture(Gesture(
+            GestureType.mouseExit,
+            gestureKind,
+            gestureLocalPosition,
+            size,
+            null,
+          ));
+        },
+      );
+    }
+    return CustomSingleChildLayout(
+      delegate: _ChartLayoutDelegate<D>(this),
+      child: child,
     );
   }
 }

--- a/lib/src/interaction/gesture.dart
+++ b/lib/src/interaction/gesture.dart
@@ -20,6 +20,20 @@ import 'signal.dart';
 /// - [Listener], which responses to common pointer events that compose [hover]
 /// and [scroll] gestures.
 enum GestureType {
+  /// Triggered when a mouse pointer has entered this widget.
+  ///
+  /// This callback is triggered when the pointer, with or without buttons
+  /// pressed, has started to be contained by the region of this widget.
+  mouseEnter,
+
+  /// Triggered when a mouse pointer has exited this widget when the widget is
+  /// still mounted.
+  ///
+  /// This callback is triggered when the pointer, with or without buttons
+  /// pressed, has stopped being contained by the region of this widget, except
+  /// when the exit is caused by the disappearance of this widget.
+  mouseExit,
+
   /// A tap with a primary button has occurred.
   ///
   /// This triggers when the tap gesture wins. If the tap gesture did not win,


### PR DESCRIPTION
Just opening this as a show-case of my failed attempt to fix #62. 

It fixes the case where the user moves the mouse outside the area of the chart, but if the user alt-tabs to another window and then back to the flutter window the tooltip is left open forever.

Maybe this is ok, and two other things could be added:
1. a TTL for tooltips
2. a way of allowing the consumer of the chart to indicate if hover is enabled, it would to the consumer to control if the window is focused or not.
 
Maybe n.2 is possible, I'm still pretty new with this lib.

Let me know your thoughts about this.