### PR TITLE
fix: add key to Chart StatefulWidget

### DIFF
--- a/lib/src/chart/chart.dart
+++ b/lib/src/chart/chart.dart
@@ -38,6 +38,7 @@ import 'view.dart';
 class Chart<D> extends StatefulWidget {
   /// Creates a chart widget.
   Chart({
+    Key? key,
     required this.data,
     this.changeData,
     required this.variables,
@@ -54,7 +55,7 @@ class Chart<D> extends StatefulWidget {
     this.gestureChannel,
     this.resizeChannel,
     this.changeDataChannel,
-  });
+  }) : super(key: key);
 
   /// The data list to visualize.
   final List<D> data;


### PR DESCRIPTION
In our application we have a usecase where we'll need to force a repaint via key change, so we need Chart's stateful widget to receive a key