### PR TITLE
feat(#85): expose selectedIndexes to tooltip renderer

### DIFF
--- a/example/lib/pages/polygon_custom.dart
+++ b/example/lib/pages/polygon_custom.dart
@@ -48,10 +48,11 @@ class TriangleShape extends IntervalShape {
   bool equalTo(Object other) => other is TriangleShape;
 }
 
-List<Figure> simpleTooltip(
-  Offset anchor,
-  List<Tuple> selectedTuples,
-) {
+List<Figure> simpleTooltip({
+  required Offset anchor,
+  required List<Tuple> selectedTuples,
+  required Set<int> selectedIndexes,
+}) {
   List<Figure> figures;
 
   String textContent = '';
@@ -127,10 +128,11 @@ List<Figure> simpleTooltip(
   return figures;
 }
 
-List<Figure> centralPieLabel(
-  Offset anchor,
-  List<Tuple> selectedTuples,
-) {
+List<Figure> centralPieLabel({
+  required Offset anchor,
+  required List<Tuple> selectedTuples,
+  required Set<int> selectedIndexes,
+}) {
   final tuple = selectedTuples.last;
 
   final titleSpan = TextSpan(

--- a/lib/src/guide/interaction/tooltip.dart
+++ b/lib/src/guide/interaction/tooltip.dart
@@ -1,9 +1,8 @@
-import 'package:graphic/src/util/collection.dart';
 import 'package:flutter/painting.dart';
 import 'package:graphic/src/chart/chart.dart';
 import 'package:graphic/src/chart/view.dart';
-import 'package:graphic/src/common/label.dart';
 import 'package:graphic/src/common/intrinsic_layers.dart';
+import 'package:graphic/src/common/label.dart';
 import 'package:graphic/src/common/operators/render.dart';
 import 'package:graphic/src/coord/coord.dart';
 import 'package:graphic/src/dataflow/tuple.dart';
@@ -13,14 +12,19 @@ import 'package:graphic/src/interaction/selection/interval.dart';
 import 'package:graphic/src/interaction/selection/selection.dart';
 import 'package:graphic/src/scale/scale.dart';
 import 'package:graphic/src/util/assert.dart';
+import 'package:graphic/src/util/collection.dart';
 
 /// Gets the figures of a tooltip.
 ///
 /// The [anchor] is the result either set directly or calculated.
-typedef TooltipRenderer = List<Figure> Function(
-  Offset anchor,
-  List<Tuple> selectedTuples,
-);
+///
+/// The [selectedTuples] and [selectedIndexes] provide the consumer with the
+/// necessary information to properly compute the content of the tooltip.
+typedef TooltipRenderer = List<Figure> Function({
+  required Offset anchor,
+  required List<Tuple> selectedTuples,
+  required Set<int> selectedIndexes,
+});
 
 /// The specification of a tooltip
 ///
@@ -268,8 +272,9 @@ class TooltipRenderOp extends Render<TooltipScene> {
     List<Figure> figures;
     if (renderer != null) {
       figures = renderer(
-        anchorRst,
-        selectedTuples,
+        anchor: anchorRst,
+        selectedTuples: selectedTuples,
+        selectedIndexes: selects,
       );
     } else {
       String textContent = '';


### PR DESCRIPTION
This is a proposal to https://github.com/entronad/graphic/issues/85 and it's a breaking change:

### Context

In our app we are using a `tooltipRenderer` but we need to be able to customize the display of each field on the tooltip based on information we dont have available in the tuples that are provided to Graphic. Therefore we need to get back the "index" of the selected tuple so that I can get the appropriate record from our data structure. Thats the gist of what we need. 

To give a bit more context, we're dynamically creating charts in a spreadsheet application with data provided by the user and, as google sheets we want to allow the user to have values with different formatting in each point. 

Here is an example where the user defined different number of decimal places per cell via formatting, ie. the user did not introduce 1.000000, the actual value is "1" but the formatting is "use 6 decimal places => 1.000000":


https://user-images.githubusercontent.com/1267623/163705323-2cd0d570-ce5c-448b-aeba-9c06f8d7c8ac.mov

## Proposal
In the tooltipRenderer return back the "selectedIndexes" to allow the user to find the appropriate record on a more complex datastructure on user-land. For users not using "tooltipRenderer", provide "tooltipFieldFormatter" which receives the selectedIndex for the current tuple being formatted.

Let me know what you think of the overall approach and if there are any alternative ways of doing this. 

Thank you.