### PR TITLE
Add size argument to custom annotation renderer method for responsiveness

### DIFF
--- a/lib/src/guide/annotation/custom.dart
+++ b/lib/src/guide/annotation/custom.dart
@@ -22,7 +22,7 @@ class CustomAnnotation extends FigureAnnotation {
         );
 
   /// Indicates the custom render funcion of this annotation.
-  List<Figure> Function(Offset) renderer;
+  List<Figure> Function(Offset, Size) renderer;
 
   @override
   bool operator ==(Object other) => other is CustomAnnotation && super == other;
@@ -35,8 +35,9 @@ class CustomAnnotOp extends FigureAnnotOp {
   @override
   List<Figure>? evaluate() {
     final anchor = params['anchor'] as Offset;
-    final renderer = params['renderer'] as List<Figure> Function(Offset);
+    final size = params['size'] as Size;
+    final renderer = params['renderer'] as List<Figure> Function(Offset, Size);
 
-    return renderer(anchor);
+    return renderer(anchor, size);
   }
 }

--- a/lib/src/parse/parse.dart
+++ b/lib/src/parse/parse.dart
@@ -634,6 +634,7 @@ void parse<D>(
           annotSpec as CustomAnnotation;
           annot = view.add(CustomAnnotOp({
             'anchor': anchor,
+            'size': size,
             'renderer': annotSpec.renderer,
           }));
         }


### PR DESCRIPTION
Right now, the custom annotation renderer method only passes an offset for the annotations' location. I have added the chart size to this to allow for responsively changing the annotation size(s) according to the chart size.

This is a breaking change, however.