### PR TITLE
fix(#84): fix DodgeModifier with symmetric flag not centering symmetrically

### DIFF
--- a/lib/src/dataflow/tuple.dart
+++ b/lib/src/dataflow/tuple.dart
@@ -6,6 +6,8 @@ import 'package:graphic/src/shape/shape.dart';
 import 'package:graphic/src/util/assert.dart';
 import 'package:graphic/src/variable/variable.dart';
 
+import '../util/collection.dart';
+
 /// The tuple to store the original values of a datum.
 ///
 /// The key strings are variable names. The value types can only be [num], [String],
@@ -70,6 +72,31 @@ class Aes {
 
   /// The represent point of [position] points.
   Offset get representPoint => shape.representPoint(position);
+
+  bool operator ==(Object other) =>
+      other is Aes &&
+      index == other.index &&
+      deepCollectionEquals(position, other.position) &&
+      shape == other.shape &&
+      color == other.color &&
+      gradient == other.gradient &&
+      elevation == other.elevation &&
+      label == other.label &&
+      size == other.size;
+
+  @override
+  String toString() {
+    return 'Aes('
+        'index: $index, '
+        'position: $position, '
+        'shape: $shape'
+        '${color != null ? ', color: $color' : ''}'
+        '${gradient != null ? ', gradient: $gradient' : ''}'
+        '${elevation != null ? ', elevation: $elevation' : ''}'
+        '${label != null ? ', label: $label' : ''}'
+        '${size != null ? ', size: $size' : ''}'
+        ')';
+  }
 }
 
 /// Aes lists for groups.

--- a/test/geom/modifier/dodge_test.dart
+++ b/test/geom/modifier/dodge_test.dart
@@ -1,0 +1,373 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphic/graphic.dart';
+import 'package:graphic/src/dataflow/tuple.dart';
+import 'package:graphic/src/geom/modifier/dodge.dart';
+
+final _color = Color(0x00000000);
+final _shape = RectShape();
+
+Aes _createAes({required int index, required List<Offset> position}) {
+  return Aes(index: index, position: position, shape: _shape, color: _color);
+}
+
+final epsilon = 0.0001;
+
+Matcher _matchesOffsets(List<List<List<Offset>>> expectedOffsets) {
+  return predicate<AesGroups>((groups) {
+    for (var groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+      final groupLength = groups[groupIndex].length;
+      for (var valueIndex = 0; valueIndex < groupLength; valueIndex++) {
+        final position = groups[groupIndex][valueIndex].position;
+        for (var positionIndex = 0;
+            positionIndex < position.length;
+            positionIndex++) {
+          final actual = position[positionIndex];
+          final expected =
+              expectedOffsets[groupIndex][valueIndex][positionIndex];
+
+          expect(actual.dx, closeTo(expected.dx, epsilon));
+          expect(actual.dy, closeTo(expected.dy, epsilon));
+        }
+      }
+    }
+
+    return true;
+  });
+}
+
+void main() {
+  group('non-symmetric', () {
+    test('shifts every X position by ratio*band', () {
+      final AesGroups groups = [
+        [
+          _createAes(index: 0, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 1, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 2, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 3, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 4, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 5, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 6, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 7, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 8, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 9, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 10, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 11, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 12, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 13, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 14, position: [Offset(0.9, 0.1)]),
+        ],
+      ];
+
+      final ratio = 1.0 / groups.length;
+      final symmetric = false;
+      final band = 1.0 / groups.first.length;
+      final modifier = DodgeGeomModifier(ratio, symmetric, band);
+      final bias = ratio * band;
+
+      modifier.modify(groups);
+
+      final expectedOffsets = [
+        [
+          [Offset(.1 + bias, .1)],
+          [Offset(.3 + bias, .1)],
+          [Offset(.5 + bias, .1)],
+          [Offset(.7 + bias, .1)],
+          [Offset(.9 + bias, .1)],
+        ],
+        [
+          [Offset(.1 + 2 * bias, .1)],
+          [Offset(.3 + 2 * bias, .1)],
+          [Offset(.5 + 2 * bias, .1)],
+          [Offset(.7 + 2 * bias, .1)],
+          [Offset(.9 + 2 * bias, .1)],
+        ],
+        [
+          [Offset(.1 + 3 * bias, .1)],
+          [Offset(.3 + 3 * bias, .1)],
+          [Offset(.5 + 3 * bias, .1)],
+          [Offset(.7 + 3 * bias, .1)],
+          [Offset(.9 + 3 * bias, .1)],
+        ],
+      ];
+
+      expect(groups, _matchesOffsets(expectedOffsets));
+    });
+  });
+  group('symmetric', () {
+    test('centers the middle Aes when there is an odd numbers of groups', () {
+      final AesGroups groups = [
+        [
+          _createAes(index: 0, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 1, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 2, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 3, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 4, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 5, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 6, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 7, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 8, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 9, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 10, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 11, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 12, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 13, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 14, position: [Offset(0.9, 0.1)]),
+        ],
+      ];
+
+      final ratio = 1.0 / groups.length;
+      final symmetric = true;
+      final band = 1.0 / groups.first.length;
+      final modifier = DodgeGeomModifier(ratio, symmetric, band);
+
+      modifier.modify(groups);
+
+      final expectedOffsets = [
+        [
+          [Offset(.1 - .2 / 3, .1)],
+          [Offset(.3 - .2 / 3, .1)],
+          [Offset(.5 - .2 / 3, .1)],
+          [Offset(.7 - .2 / 3, .1)],
+          [Offset(.9 - .2 / 3, .1)],
+        ],
+        [
+          [Offset(.1, .1)],
+          [Offset(.3, .1)],
+          [Offset(.5, .1)],
+          [Offset(.7, .1)],
+          [Offset(.9, .1)],
+        ],
+        [
+          [Offset(.1 + .2 / 3, .1)],
+          [Offset(.3 + .2 / 3, .1)],
+          [Offset(.5 + .2 / 3, .1)],
+          [Offset(.7 + .2 / 3, .1)],
+          [Offset(.9 + .2 / 3, .1)],
+        ],
+      ];
+
+      expect(groups, _matchesOffsets(expectedOffsets));
+    });
+
+    test(
+        'centers the middle Aes when there is an odd numbers of groups and ratio is 0.1',
+        () {
+      final AesGroups groups = [
+        [
+          _createAes(index: 0, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 1, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 2, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 3, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 4, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 5, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 6, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 7, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 8, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 9, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 10, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 11, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 12, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 13, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 14, position: [Offset(0.9, 0.1)]),
+        ],
+      ];
+
+      final ratio = 0.1;
+      final symmetric = true;
+      final band = 1.0 / groups.first.length;
+      final modifier = DodgeGeomModifier(ratio, symmetric, band);
+
+      modifier.modify(groups);
+
+      final expectedOffsets = [
+        [
+          [Offset(.08, .1)],
+          [Offset(.28, .1)],
+          [Offset(.48, .1)],
+          [Offset(.68, .1)],
+          [Offset(.88, .1)],
+        ],
+        [
+          [Offset(.1, .1)],
+          [Offset(.3, .1)],
+          [Offset(.5, .1)],
+          [Offset(.7, .1)],
+          [Offset(.9, .1)],
+        ],
+        [
+          [Offset(.12, .1)],
+          [Offset(.32, .1)],
+          [Offset(.52, .1)],
+          [Offset(.72, .1)],
+          [Offset(.92, .1)],
+        ],
+      ];
+
+      expect(groups, _matchesOffsets(expectedOffsets));
+    });
+
+    test(
+        'positions the groups equidistant from the center point when there is an even numbers of groups',
+        () {
+      final AesGroups groups = [
+        [
+          _createAes(index: 0, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 1, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 2, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 3, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 4, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 5, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 6, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 7, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 8, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 9, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 10, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 11, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 12, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 13, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 14, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 15, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 16, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 17, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 18, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 19, position: [Offset(0.9, 0.1)]),
+        ],
+      ];
+
+      final ratio = 1.0 / groups.length;
+      final symmetric = true;
+      final band = 1.0 / groups.first.length;
+      final modifier = DodgeGeomModifier(ratio, symmetric, band);
+
+      modifier.modify(groups);
+
+      final expectedOffsets = [
+        [
+          [Offset(.1 - 0.075, .1)],
+          [Offset(.3 - 0.075, .1)],
+          [Offset(.5 - 0.075, .1)],
+          [Offset(.7 - 0.075, .1)],
+          [Offset(.9 - 0.075, .1)],
+        ],
+        [
+          [Offset(.1 - 0.025, .1)],
+          [Offset(.3 - 0.025, .1)],
+          [Offset(.5 - 0.025, .1)],
+          [Offset(.7 - 0.025, .1)],
+          [Offset(.9 - 0.025, .1)],
+        ],
+        [
+          [Offset(.1 + 0.025, .1)],
+          [Offset(.3 + 0.025, .1)],
+          [Offset(.5 + 0.025, .1)],
+          [Offset(.7 + 0.025, .1)],
+          [Offset(.9 + 0.025, .1)],
+        ],
+        [
+          [Offset(.1 + 0.075, .1)],
+          [Offset(.3 + 0.075, .1)],
+          [Offset(.5 + 0.075, .1)],
+          [Offset(.7 + 0.075, .1)],
+          [Offset(.9 + 0.075, .1)],
+        ],
+      ];
+
+      expect(groups, _matchesOffsets(expectedOffsets));
+    });
+
+    test(
+        'positions the groups equidistant from the center point when there is an even numbers of groups and ratio is 0.1',
+        () {
+      final AesGroups groups = [
+        [
+          _createAes(index: 0, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 1, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 2, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 3, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 4, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 5, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 6, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 7, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 8, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 9, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 10, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 11, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 12, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 13, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 14, position: [Offset(0.9, 0.1)]),
+        ],
+        [
+          _createAes(index: 15, position: [Offset(0.1, 0.1)]),
+          _createAes(index: 16, position: [Offset(0.3, 0.1)]),
+          _createAes(index: 17, position: [Offset(0.5, 0.1)]),
+          _createAes(index: 18, position: [Offset(0.7, 0.1)]),
+          _createAes(index: 19, position: [Offset(0.9, 0.1)]),
+        ],
+      ];
+
+      final ratio = 0.1;
+      final symmetric = true;
+      final band = 1.0 / groups.first.length;
+      final modifier = DodgeGeomModifier(ratio, symmetric, band);
+
+      modifier.modify(groups);
+
+      final expectedOffsets = [
+        [
+          [Offset(.07, .1)],
+          [Offset(.27, .1)],
+          [Offset(.47, .1)],
+          [Offset(.67, .1)],
+          [Offset(.87, .1)],
+        ],
+        [
+          [Offset(.09, .1)],
+          [Offset(.29, .1)],
+          [Offset(.49, .1)],
+          [Offset(.69, .1)],
+          [Offset(.89, .1)],
+        ],
+        [
+          [Offset(.11, .1)],
+          [Offset(.31, .1)],
+          [Offset(.51, .1)],
+          [Offset(.71, .1)],
+          [Offset(.91, .1)],
+        ],
+        [
+          [Offset(.13, .1)],
+          [Offset(.33, .1)],
+          [Offset(.53, .1)],
+          [Offset(.73, .1)],
+          [Offset(.93, .1)],
+        ],
+      ];
+
+      expect(groups, _matchesOffsets(expectedOffsets));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #84.

The `DodgeModifier` wasn't correctly centering the values around the original position. This pull request fixes that issue. 
I've also added tests to ensure that it works now and it doesn't break in the future.

Used [`ggplot`'s dodging documentation](https://ggplot2.tidyverse.org/reference/position_dodge.html#ref-examples) as a comparison for this modifier.

Before (`main`):

<img width="373" alt="image" src="https://user-images.githubusercontent.com/12778398/163787653-20847c8a-ebb4-4b4a-9b02-2f9731886b1b.png">

Note how the `0` label wasn't properly centered with relation to the vertical bars.

Now (`fix/dodge-modifier-symmetric`):

<img width="392" alt="image" src="https://user-images.githubusercontent.com/12778398/163787530-b62e1f79-7fb0-4a7e-9bb2-1dd415fb63dc.png">

Note how the `0` label is now properly centered with relation to the vertical bars.