### PR TITLE
improv: add custom modifier example

### DIFF
--- a/lib/src/geom/modifier/modifier.dart
+++ b/lib/src/geom/modifier/modifier.dart
@@ -18,7 +18,7 @@ import 'package:graphic/src/shape/shape.dart';
 /// Rendering customization should be in the [Shape].
 abstract class Modifier extends CustomizableSpec {
   /// Modifies the position of element items.
-  /// 
+  ///
   /// The aesthetic attributes are in the [groups].
   void modify(
     AesGroups groups,


### PR DESCRIPTION
This PR adds an example of a custom `Modifier`. It creates a `DodgeSizeModifier` that changes an element's position and width depending on the number of elements in a band. 

<table class="tg">
<thead>
  <tr>
    <th class="tg-0pky">Custom Legend Example</th>
    <th class="tg-0pky">Custom Modifier Example</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td class="tg-0pky">
<img width="383" alt="image" src="https://user-images.githubusercontent.com/12778398/164427437-1e737ad9-d781-46be-92ff-79470f195f59.png">

</td>
<td>
<img width="378" alt="image" src="https://user-images.githubusercontent.com/12778398/164427459-443129a5-2800-47f9-b211-0a7550898763.png">

</td>
  </tr>
</tbody>
</table>