### PR TITLE
fix(#95): fix Stack Overflow when comparing modifiers

### DIFF
--- a/lib/src/geom/modifier/dodge.dart
+++ b/lib/src/geom/modifier/dodge.dart
@@ -1,10 +1,10 @@
 import 'dart:ui';
 
+import 'package:graphic/src/algebra/varset.dart';
 import 'package:graphic/src/coord/coord.dart';
 import 'package:graphic/src/dataflow/tuple.dart';
 import 'package:graphic/src/scale/discrete.dart';
 import 'package:graphic/src/scale/scale.dart';
-import 'package:graphic/src/algebra/varset.dart';
 
 import 'modifier.dart';
 
@@ -32,7 +32,6 @@ class DodgeModifier extends Modifier {
   @override
   bool equalTo(Object other) =>
       other is DodgeModifier &&
-      super == other &&
       ratio == other.ratio &&
       symmetric == other.symmetric;
 

--- a/lib/src/geom/modifier/jitter.dart
+++ b/lib/src/geom/modifier/jitter.dart
@@ -1,11 +1,11 @@
-import 'dart:ui';
 import 'dart:math';
+import 'dart:ui';
 
+import 'package:graphic/src/algebra/varset.dart';
 import 'package:graphic/src/coord/coord.dart';
 import 'package:graphic/src/dataflow/tuple.dart';
 import 'package:graphic/src/scale/discrete.dart';
 import 'package:graphic/src/scale/scale.dart';
-import 'package:graphic/src/algebra/varset.dart';
 
 import 'modifier.dart';
 
@@ -25,8 +25,7 @@ class JitterModifier extends Modifier {
   double? ratio;
 
   @override
-  bool equalTo(Object other) =>
-      other is JitterModifier && super == other && ratio == other.ratio;
+  bool equalTo(Object other) => other is JitterModifier && ratio == other.ratio;
 
   @override
   void modify(AesGroups groups, Map<String, ScaleConv<dynamic, num>> scales,

--- a/lib/src/geom/modifier/stack.dart
+++ b/lib/src/geom/modifier/stack.dart
@@ -18,7 +18,7 @@ import 'modifier.dart';
 /// - Y values must be all positive or all negtive.
 class StackModifier extends Modifier {
   @override
-  bool equalTo(Object other) => other is StackModifier && super == other;
+  bool equalTo(Object other) => other is StackModifier;
 
   void modify(AesGroups groups, Map<String, ScaleConv<dynamic, num>> scales,
       AlgForm form, CoordConv coord, Offset origin) {

--- a/lib/src/geom/modifier/symmetric.dart
+++ b/lib/src/geom/modifier/symmetric.dart
@@ -1,5 +1,5 @@
-import 'dart:ui';
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:graphic/src/algebra/varset.dart';
 import 'package:graphic/src/coord/coord.dart';
@@ -16,8 +16,7 @@ import 'modifier.dart';
 /// It is mostly used in river chart, and funnel chart.
 class SymmetricModifier extends Modifier {
   @override
-  bool operator ==(Object other) =>
-      other is SymmetricModifier && super == other;
+  bool operator ==(Object other) => other is SymmetricModifier;
 
   @override
   bool equalTo(Object other) => other is SymmetricModifier && super == other;

--- a/test/geom/modifier/dodge.dart
+++ b/test/geom/modifier/dodge.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphic/graphic.dart';
+
+void main() {
+  group('equalTo', () {
+    test('returns true when type is `DodgeModifier` and properties are equal',
+        () {
+      expect(DodgeModifier() == DodgeModifier(), true);
+      expect(
+          DodgeModifier(ratio: 0.5, symmetric: false) ==
+              DodgeModifier(ratio: 0.5, symmetric: false),
+          true);
+    });
+
+    test('returns false when type is not `DodgeModifier`', () {
+      expect(DodgeModifier() == SymmetricModifier(), false);
+    });
+
+    test('returns false when some property differs', () {
+      expect(DodgeModifier(ratio: 0.1) == DodgeModifier(ratio: 0.2), false);
+      expect(DodgeModifier(symmetric: true) == DodgeModifier(symmetric: false),
+          false);
+    });
+  });
+}

--- a/test/geom/modifier/jitter.dart
+++ b/test/geom/modifier/jitter.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphic/graphic.dart';
+
+void main() {
+  group('equalTo', () {
+    test('returns true when type is `JitterModifier` and properties are equal',
+        () {
+      expect(JitterModifier() == JitterModifier(), true);
+      expect(JitterModifier(ratio: 0.25) == JitterModifier(ratio: 0.25), true);
+    });
+
+    test('returns false when type is not `JitterModifier`', () {
+      expect(JitterModifier() == SymmetricModifier(), false);
+    });
+
+    test('returns false when some property differs', () {
+      expect(JitterModifier(ratio: 0.25) == JitterModifier(ratio: 0.3), false);
+    });
+  });
+}

--- a/test/geom/modifier/stack.dart
+++ b/test/geom/modifier/stack.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphic/graphic.dart';
+
+void main() {
+  group('equalTo', () {
+    test('returns true when type is `StackModifier`', () {
+      expect(StackModifier() == StackModifier(), true);
+    });
+
+    test('returns false when type is not `StackModifier`', () {
+      expect(StackModifier() == DodgeModifier(), false);
+    });
+  });
+}

--- a/test/geom/modifier/symmetric.dart
+++ b/test/geom/modifier/symmetric.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphic/graphic.dart';
+
+void main() {
+  group('equalTo', () {
+    test('returns true when type is `SymmetricModifier`', () {
+      expect(SymmetricModifier() == SymmetricModifier(), true);
+    });
+
+    test('returns false when type is not `SymmetricModifier`', () {
+      expect(SymmetricModifier() == DodgeModifier(), false);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #95 

Removes the `super == other` comparison, which caused the `equalTo` function to be called and resulted in an infinite loop, eventually causing the `StackOverflowException`. 

Also adds tests to ensure this error does not happen in the future.