### PR TITLE
Proportional IntervalElement width

### DIFF
--- a/example/lib/pages/interval.dart
+++ b/example/lib/pages/interval.dart
@@ -20,6 +20,7 @@ class IntervalPage extends StatelessWidget {
         child: Center(
           child: Column(
             children: <Widget>[
+              // Interactive Bar Chart 
               Container(
                 child: const Text(
                   'Interactive Bar Chart',
@@ -89,6 +90,8 @@ class IntervalPage extends StatelessWidget {
                   crosshair: CrosshairGuide(),
                 ),
               ),
+              
+              // Transposed Bar Chart
               Container(
                 child: const Text(
                   'Transposed Bar Chart',
@@ -99,6 +102,15 @@ class IntervalPage extends StatelessWidget {
               Container(
                 child: const Text(
                   '- Uses gradient attribute instead of color.',
+                ),
+                padding: const EdgeInsets.fromLTRB(10, 5, 10, 0),
+                alignment: Alignment.centerLeft,
+              ),
+              Container(
+                child: const Text(
+                  "- Size attributes between 0 and 1 is proportional to "
+                  " available space. In this case, size is 0.2 for each"
+                  " bar, filling the entire space",
                 ),
                 padding: const EdgeInsets.fromLTRB(10, 5, 10, 0),
                 alignment: Alignment.centerLeft,
@@ -144,6 +156,9 @@ class IntervalPage extends StatelessWidget {
                                   ])
                             }
                           }),
+                      size: SizeAttr(
+                        encoder: (_)=>1.0 / basicData.length
+                      )
                     )
                   ],
                   coord: RectCoord(transposed: true),
@@ -158,6 +173,8 @@ class IntervalPage extends StatelessWidget {
                   selections: {'tap': PointSelection(dim: Dim.x)},
                 ),
               ),
+              
+              // Interval Bar Chart
               Container(
                 child: const Text(
                   'Interval Bar Chart',
@@ -212,6 +229,8 @@ class IntervalPage extends StatelessWidget {
                   ],
                 ),
               ),
+              
+              // Stacked Bar Chart
               Container(
                 child: const Text(
                   'Stacked Bar Chart',
@@ -293,6 +312,8 @@ class IntervalPage extends StatelessWidget {
                   crosshair: CrosshairGuide(),
                 ),
               ),
+              
+              // Funnel Chart
               Container(
                 child: const Text(
                   'Funnel Chart',
@@ -381,6 +402,8 @@ class IntervalPage extends StatelessWidget {
                   coord: PolarCoord(transposed: true, dimCount: 1),
                 ),
               ),
+              
+              // Rose Chart
               Container(
                 child: const Text(
                   'Rose Chart',
@@ -427,6 +450,8 @@ class IntervalPage extends StatelessWidget {
                   coord: PolarCoord(startRadius: 0.15),
                 ),
               ),
+              
+              // Stacked Rose Chart
               Container(
                 child: const Text(
                   'Stacked Rose Chart',
@@ -485,12 +510,21 @@ class IntervalPage extends StatelessWidget {
                   ),
                 ),
               ),
+              
+              // Race Chart
               Container(
                 child: const Text(
                   'Race Chart',
                   style: TextStyle(fontSize: 20),
                 ),
                 padding: const EdgeInsets.fromLTRB(20, 40, 20, 5),
+              ),
+              Container(
+                child: const Text(
+                  '- Proportional bar\'s width works as well.',
+                ),
+                padding: const EdgeInsets.fromLTRB(10, 5, 10, 0),
+                alignment: Alignment.centerLeft,
               ),
               Container(
                 margin: const EdgeInsets.only(top: 10),
@@ -515,6 +549,7 @@ class IntervalPage extends StatelessWidget {
                         variable: 'genre',
                         values: Defaults.colors10,
                       ),
+                      size: SizeAttr(encoder: (_)=> (1.0/basicData.length)-0.01 ),
                     )
                   ],
                   coord: PolarCoord(transposed: true),

--- a/lib/src/shape/interval.dart
+++ b/lib/src/shape/interval.dart
@@ -134,7 +134,16 @@ class RectShape extends IntervalShape {
 
           final start = coord.convert(item.position[0]);
           final end = coord.convert(item.position[1]);
-          final size = item.size ?? defaultSize;
+          // When item.size is between 0 and 1, we set it
+          // proportionally from the available space 
+          double size = item.size ?? defaultSize;
+          if( size > 0.0 && size < 1.0 ){
+            if( coord.transposed )
+              size = coord.region.height * size;
+            else 
+              size = coord.region.width * size;
+          }
+          
           Rect rect;
           if (coord.transposed) {
             rect = Rect.fromLTRB(
@@ -188,7 +197,15 @@ class RectShape extends IntervalShape {
           for (var item in group) {
             final position = item.position;
             final r = coord.convertRadius(position[0].dx);
-            final halfSize = (item.size ?? defaultSize) / 2;
+            
+            // When item.size is between 0 and 1, we set it
+            // proportionally from the available space 
+            double size = item.size ?? defaultSize;
+            if( size > 0.0 && size < 1.0 ){
+              size = coord.region.height * size;
+            }
+            final halfSize = size / 4;
+
             rst.addAll(_renderSector(
               item,
               r + halfSize,


### PR DESCRIPTION
When Size Attribute is a double between 0 and 1, it works proportional to available space (0.5 would mean half the axis).
Works on RectCoord and PolarCoord+Transposed graphs. 
This was the better way I could imagine to fill an OK space on dynamic-sized graphs. 

Also, I've updated the examples (IntervalElements) with it