### PR TITLE
improv: expose linearNiceRange and linearNiceNumbers algorithms

### DIFF
--- a/lib/graphic.dart
+++ b/lib/graphic.dart
@@ -131,6 +131,8 @@ export 'src/scale/continuous.dart' show ContinuousScale, ContinuousScaleConv;
 export 'src/scale/linear.dart' show LinearScale, LinearScaleConv;
 export 'src/scale/ordinal.dart' show OrdinalScale, OrdinalScaleConv;
 export 'src/scale/time.dart' show TimeScale, TimeScaleConv;
+export 'src/scale/util/nice_numbers.dart' show linearNiceNumbers;
+export 'src/scale/util/nice_range.dart' show linearNiceRange;
 
 export 'src/geom/element.dart' show GeomElement;
 export 'src/geom/function.dart' show FunctionElement;


### PR DESCRIPTION
Exposes `linearNiceRange` and `linearNiceNumbers` algorithms. 

In our use case, we need to measure the size of the ticks so we can compute the size of the vertical axis. 
For simplicity sake, I thought that exposing these algorithms would be a nice solution. 

This way, our code uses the same algorithm as graphic, but then we apply our logic, and feed it back to graphic.

Concluding, we need these algorithms to measure the width of the vertical axis to make it dynamic. Another solution would be to add this dynamism to graphic, but I think that would require more effort. Looking forward to your suggestion