### PR TITLE
fix: handle big numbers when calculating nice range/numbers

### DIFF
--- a/lib/src/scale/util/nice_numbers.dart
+++ b/lib/src/scale/util/nice_numbers.dart
@@ -144,7 +144,7 @@ List<num> _wilkinsonExtended(
         int z = (dart_math.log(delta) / dart_math.ln10).ceil();
 
         while (z < _maxLoop) {
-          final step = j * q * dart_math.pow(10, z);
+          final step = j * q * dart_math.pow(10.toDouble(), z);
           final cm = _coverageMax(min, max, (step * (k - 1)));
 
           if (w[0] * sm + w[1] * cm + w[2] * dm + w[3] < bestScore) {

--- a/lib/src/scale/util/nice_numbers.dart
+++ b/lib/src/scale/util/nice_numbers.dart
@@ -144,7 +144,7 @@ List<num> _wilkinsonExtended(
         int z = (dart_math.log(delta) / dart_math.ln10).ceil();
 
         while (z < _maxLoop) {
-          final step = j * q * dart_math.pow(10.toDouble(), z);
+          final step = j * q * dart_math.pow(10.0, z);
           final cm = _coverageMax(min, max, (step * (k - 1)));
 
           if (w[0] * sm + w[1] * cm + w[2] * dm + w[3] < bestScore) {

--- a/lib/src/scale/util/nice_range.dart
+++ b/lib/src/scale/util/nice_range.dart
@@ -20,9 +20,9 @@ num _tickIncrement(
                 : error >= _e2
                     ? 2
                     : 1) *
-        dart_math.pow(10.toDouble(), power);
+        dart_math.pow(10.0, power);
   }
-  return -dart_math.pow(10.toDouble(), -power) /
+  return -dart_math.pow(10.0, -power) /
       (error >= _e10
           ? 10
           : error >= _e5

--- a/lib/src/scale/util/nice_range.dart
+++ b/lib/src/scale/util/nice_range.dart
@@ -20,9 +20,9 @@ num _tickIncrement(
                 : error >= _e2
                     ? 2
                     : 1) *
-        dart_math.pow(10, power);
+        dart_math.pow(10.toDouble(), power);
   }
-  return -dart_math.pow(10, -power) /
+  return -dart_math.pow(10.toDouble(), -power) /
       (error >= _e10
           ? 10
           : error >= _e5

--- a/test/scale/util/nice_number_test.dart
+++ b/test/scale/util/nice_number_test.dart
@@ -54,5 +54,11 @@ main() {
       expect(linearNiceNumbers(-1.02835066, 3.25839303, 5),
           [-1.2, 0, 1.2, 2.4, 3.6]);
     });
+
+    test('Nice numbers with values that overflow ints', () {
+      expect(linearNiceNumbers(0.0, 1e30, 5), [0, 3e29, 6e29, 9e29, 1.2e30]);
+
+      expect(linearNiceNumbers(0.0, 1e32, 5), [0, 3e31, 6e31, 9e31, 1.2e32]);
+    });
   });
 }

--- a/test/scale/util/nice_range_test.dart
+++ b/test/scale/util/nice_range_test.dart
@@ -15,4 +15,16 @@ main() {
 
     expect(linearNiceRange(0.4, 0.6, 5), [0.4, 0.6]);
   });
+
+  test('Linear Nice range with values that overflow ints', () {
+    expect(
+      linearNiceRange(0, 999999999999999999999999999999.0, 5),
+      [0.0, 1.9999999999999998e+30],
+    );
+
+    expect(
+      linearNiceRange(0, 9999999999999999999999999999999.0, 5),
+      [0.0, 1e31],
+    );
+  });
 }


### PR DESCRIPTION
# Problem

Currently, `graphic` throws an error when calculating the `step` in `linearNiceRange` when using big numbers (e.g., `999999999999999999999999999999`). 

This happens because the `step` is being stored in an int which overflows and becomes negative. 

In `_tickIncrement` we calculate the `dart_math.log(step)`, which returns `NaN` because `step` is negative, which crashes the algorithm.

A similar thing happens in `linearNiceNumbers`.

# Solution

By using a `double` instead of an `int` for storing the `step`, we are sure it never overflows. It may lose some precision, which I'd argue is ok, since this is a visualization tool and eyes can't see that precisely, but it doesn't throw an exception due to an overflow.

I'm open to other solutions as well, but this one seems to fix the aforementioned issue and does minimal impact.

Let me know what you think 😄 