### PR TITLE
add mouse-focus scaling signal

### DIFF
--- a/lib/src/common/defaults.dart
+++ b/lib/src/common/defaults.dart
@@ -58,9 +58,9 @@ SignalUpdater<List<double>> _getRangeUpdate(
           } else {
             double mousePos;
             if (isHorizontal) {
-              mousePos = gesture.localPosition.dx / gesture.chartSize.width / 0.94 - 0.052527;
+              mousePos = (gesture.localPosition.dx - 39.5) / (gesture.chartSize.width - 51);
             } else {
-              mousePos = 1 - (gesture.localPosition.dy / gesture.chartSize.height / 0.975 - 0.006410);
+              mousePos = 1 - (gesture.localPosition.dy - 5) / (gesture.chartSize.height - 25);
             }
             mousePos = (mousePos - pre.first) / (pre.last - pre.first);
             return [

--- a/lib/src/common/defaults.dart
+++ b/lib/src/common/defaults.dart
@@ -58,9 +58,9 @@ SignalUpdater<List<double>> _getRangeUpdate(
           } else {
             double mousePos;
             if (isHorizontal) {
-              mousePos = gesture.localPosition.dx / 752 - 0.052527;
+              mousePos = gesture.localPosition.dx / gesture.chartSize.width / 0.94 - 0.052527;
             } else {
-              mousePos = 1 - (gesture.localPosition.dy / 780 - 0.006410);
+              mousePos = 1 - (gesture.localPosition.dy / gesture.chartSize.height / 0.975 - 0.006410);
             }
             mousePos = (mousePos - pre.first) / (pre.last - pre.first);
             return [

--- a/lib/src/common/defaults.dart
+++ b/lib/src/common/defaults.dart
@@ -8,9 +8,7 @@ import 'package:graphic/src/interaction/gesture.dart';
 
 /// Gets signal update for different dimensions.
 SignalUpdater<List<double>> _getRangeUpdate(
-        double Function(ScaleUpdateDetails) getDeltaDim,
-        double Function(ScaleUpdateDetails) getScaleDim,
-        double Function(Size) getSizeDim) =>
+        bool isHorizontal, bool focusMouseScale) =>
     (
       List<double> init,
       List<double> pre,
@@ -25,12 +23,19 @@ SignalUpdater<List<double>> _getRangeUpdate(
           if (detail.pointerCount == 1) {
             // Panning.
 
-            final deltaRatio = getDeltaDim(gesture.preScaleDetail!);
-            final delta = deltaRatio / getSizeDim(gesture.chartSize);
+            final deltaRatio = isHorizontal
+                ? gesture.preScaleDetail!.focalPointDelta.dx
+                : -gesture.preScaleDetail!.focalPointDelta.dy;
+            final delta = deltaRatio /
+                (isHorizontal
+                    ? gesture.chartSize.width
+                    : gesture.chartSize.height);
             return [pre.first + delta, pre.last + delta];
           } else {
             // Scaling.
 
+            double Function(ScaleUpdateDetails) getScaleDim =
+                (p0) => isHorizontal ? p0.horizontalScale : p0.verticalScale;
             final preScale = getScaleDim(gesture.preScaleDetail!);
             final scale = getScaleDim(detail);
             final deltaRatio = (scale - preScale) / preScale / 2;
@@ -39,7 +44,7 @@ SignalUpdater<List<double>> _getRangeUpdate(
             return [pre.first - delta, pre.last + delta];
           }
         } else if (gesture.type == GestureType.scroll) {
-          const step = 0.1;
+          const step = -0.1;
           final scrollDelta = gesture.details as Offset;
           final deltaRatio = scrollDelta.dy == 0
               ? 0.0
@@ -48,7 +53,21 @@ SignalUpdater<List<double>> _getRangeUpdate(
                   : (-step / 2);
           final preRange = pre.last - pre.first;
           final delta = deltaRatio * preRange;
-          return [pre.first - delta, pre.last + delta];
+          if (!focusMouseScale) {
+            return [pre.first - delta, pre.last + delta];
+          } else {
+            double mousePos;
+            if (isHorizontal) {
+              mousePos = gesture.localPosition.dx / 752 - 0.052527;
+            } else {
+              mousePos = 1 - (gesture.localPosition.dy / 780 - 0.006410);
+            }
+            mousePos = (mousePos - pre.first) / (pre.last - pre.first);
+            return [
+              pre.first - delta * 2 * mousePos,
+              pre.last + delta * 2 * (1 - mousePos)
+            ];
+          }
         } else if (gesture.type == GestureType.doubleTap) {
           return init;
         }
@@ -158,16 +177,17 @@ abstract class Defaults {
 
   /// A signal update for scaling and panning horizontal coordinate range.
   static SignalUpdater<List<double>> get horizontalRangeSignal =>
-      _getRangeUpdate(
-        (detail) => detail.focalPointDelta.dx,
-        (detail) => detail.horizontalScale,
-        (size) => size.width,
-      );
+      _getRangeUpdate(true, false);
 
   /// A signal update for scaling and panning vertical coordinate range.
-  static SignalUpdater<List<double>> get verticalRangeSignal => _getRangeUpdate(
-        (detail) => -detail.focalPointDelta.dy,
-        (detail) => detail.verticalScale,
-        (size) => size.height,
-      );
+  static SignalUpdater<List<double>> get verticalRangeSignal =>
+      _getRangeUpdate(false, false);
+
+  /// A signal update for scaling and panning horizontal coordinate range by cursor focus.
+  static SignalUpdater<List<double>> get horizontalRangeFocusSignal =>
+      _getRangeUpdate(true, true);
+
+  /// A signal update for scaling and panning vertical coordinate range by cursor focus.
+  static SignalUpdater<List<double>> get verticalRangeFocusSignal =>
+      _getRangeUpdate(false, true);
 }


### PR DESCRIPTION
This PR adds two default signals for scrolling the mouse wheel when the mouse pointer is over the chart, which will focus on the mouse position and then zoom freely, which is more in line with user habits than the original signal. 
Run test:
```dart
import 'package:flutter/material.dart';
import 'package:graphic/graphic.dart';

import '../data.dart';

class LineAreaPointPage extends StatelessWidget {
  const LineAreaPointPage({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('Line and Area Element'),
      ),
      backgroundColor: Colors.white,
      body: Column(children: [
        Center(
          child: Container(
            margin: const EdgeInsets.only(top: 10),
            width: 800,
            height: 800,
            child: Chart(
              data: scatterData,
              variables: {
                '0': Variable(
                  accessor: (List datum) => datum[0] as num,
                  scale: LinearScale(min: -200, max: 200),
                ),
                '1': Variable(
                  accessor: (List datum) => datum[1] as num,
                  scale: LinearScale(min: -200, max: 200),
                ),
                '2': Variable(accessor: (List datum) => datum[2] as num),
                '4': Variable(accessor: (List datum) => datum[4].toString()),
              },
              elements: [
                PointElement(
                  size: SizeAttr(variable: '2', values: [10, 5]),
                  color: ColorAttr(
                    variable: '4',
                    values: Defaults.colors10,
                    updaters: {
                      'choose': {true: (_) => Colors.red}
                    },
                  ),
                  shape: ShapeAttr(variable: '4', values: [
                    CircleShape(hollow: false),
                    CircleShape(hollow: false),
                  ]),
                )
              ],
              axes: [
                Defaults.horizontalAxis
                  ..position = 0
                  ..grid = Defaults.strokeStyle
                  ..line = Defaults.strokeStyle,
                Defaults.verticalAxis
                  ..position = 0
                  ..grid = Defaults.strokeStyle
                  ..line = Defaults.strokeStyle,
              ],
              coord: RectCoord(
                horizontalRange: [0, 1],
                verticalRange: [0, 1],
                horizontalRangeUpdater: Defaults.horizontalRangeFocusSignal,
                verticalRangeUpdater: Defaults.verticalRangeFocusSignal,
              ),
              selections: {'choose': PointSelection(toggle: true)},
              tooltip: TooltipGuide(
                anchor: (_) => Offset.zero,
                align: Alignment.bottomRight,
                multiTuples: true,
              ),
            ),
          ),
        ),
      ]),
    );
  }
}
```