### PR TITLE
User-friendly way to customize the tooltip text

### DIFF
--- a/example/lib/pages/echarts.dart
+++ b/example/lib/pages/echarts.dart
@@ -219,7 +219,7 @@ class EchartsPage extends StatelessWidget {
                   tooltip: TooltipGuide(
                     followPointer: [true, true],
                     align: Alignment.topLeft,
-                    variables: ['group', 'value'],
+                    getTooltipText: (vars) => "group: ${vars['group']}, value: ${vars['value']}",
                   ),
                   crosshair: CrosshairGuide(
                     followPointer: [false, true],

--- a/example/lib/pages/interaction_channel_dynamic.dart
+++ b/example/lib/pages/interaction_channel_dynamic.dart
@@ -323,7 +323,7 @@ class _InteractionChannelDynamicPageState
                     backgroundColor: Colors.black,
                     elevation: 5,
                     textStyle: Defaults.textStyle,
-                    variables: ['genre', 'sold'],
+                    getTooltipText: (vars) => "genre: ${vars['genre']}, sold: ${vars['sold']}",
                   ),
                   crosshair: CrosshairGuide(),
                 ),

--- a/example/lib/pages/interval.dart
+++ b/example/lib/pages/interval.dart
@@ -283,7 +283,7 @@ class IntervalPage extends StatelessWidget {
                       variable: 'index',
                     )
                   },
-                  tooltip: TooltipGuide(multiTuples: true),
+                  tooltip: TooltipGuide(),
                   crosshair: CrosshairGuide(),
                 ),
               ),
@@ -473,7 +473,6 @@ class IntervalPage extends StatelessWidget {
                     )
                   },
                   tooltip: TooltipGuide(
-                    multiTuples: true,
                     anchor: (_) => Offset.zero,
                     align: Alignment.bottomRight,
                   ),

--- a/example/lib/pages/line_area_point.dart
+++ b/example/lib/pages/line_area_point.dart
@@ -302,11 +302,7 @@ class LineAreaPointPage extends StatelessWidget {
                     followPointer: [true, true],
                     align: Alignment.topLeft,
                     element: 0,
-                    variables: [
-                      'date',
-                      'name',
-                      'points',
-                    ],
+                    getTooltipText: (vars) => "date: ${vars['date']}, name: ${vars['name']}, points: ${vars['points']}",
                   ),
                   crosshair: CrosshairGuide(
                     selections: {'tooltipTouch', 'tooltipMouse'},
@@ -375,8 +371,7 @@ class LineAreaPointPage extends StatelessWidget {
                     followPointer: [false, true],
                     align: Alignment.topLeft,
                     offset: const Offset(-20, -20),
-                    multiTuples: true,
-                    variables: ['type', 'value'],
+                    getTooltipText: (vars) => "type: ${vars['type']}, value: ${vars['value']}",
                   ),
                   crosshair: CrosshairGuide(followPointer: [false, true]),
                 ),
@@ -440,8 +435,7 @@ class LineAreaPointPage extends StatelessWidget {
                   tooltip: TooltipGuide(
                     anchor: (_) => Offset.zero,
                     align: Alignment.bottomRight,
-                    multiTuples: true,
-                    variables: ['type', 'value'],
+                    getTooltipText: (vars) => "type: ${vars['type']}, value: ${vars['value']}",
                   ),
                   crosshair: CrosshairGuide(followPointer: [false, true]),
                 ),
@@ -524,7 +518,6 @@ class LineAreaPointPage extends StatelessWidget {
                   tooltip: TooltipGuide(
                     anchor: (_) => Offset.zero,
                     align: Alignment.bottomRight,
-                    multiTuples: true,
                   ),
                 ),
               ),
@@ -610,7 +603,6 @@ class LineAreaPointPage extends StatelessWidget {
                   tooltip: TooltipGuide(
                     anchor: (_) => Offset.zero,
                     align: Alignment.bottomRight,
-                    multiTuples: true,
                   ),
                 ),
               ),
@@ -688,7 +680,6 @@ class LineAreaPointPage extends StatelessWidget {
                   tooltip: TooltipGuide(
                     anchor: (_) => Offset.zero,
                     align: Alignment.bottomRight,
-                    multiTuples: true,
                   ),
                   annotations: [
                     TagAnnotation(

--- a/example/lib/pages/polygon_custom.dart
+++ b/example/lib/pages/polygon_custom.dart
@@ -556,7 +556,7 @@ class PolygonCustomPage extends StatelessWidget {
                       variable: 'index',
                     )
                   },
-                  tooltip: TooltipGuide(multiTuples: true),
+                  tooltip: TooltipGuide(),
                   crosshair: CrosshairGuide(),
                   annotations: [
                     MarkAnnotation(

--- a/lib/src/parse/parse.dart
+++ b/lib/src/parse/parse.dart
@@ -676,12 +676,11 @@ void parse<D>(
             color: Color(0xff595959),
             fontSize: 12,
           ),
-      'multiTuples': tooltipSpec.multiTuples,
       'renderer': tooltipSpec.renderer,
       'followPointer': tooltipSpec.followPointer ?? [false, false],
       'anchor': tooltipSpec.anchor,
       'size': size,
-      'variables': tooltipSpec.variables,
+      'getTooltipText': tooltipSpec.getTooltipText,
       'constrained': tooltipSpec.constrained ?? true,
       'scales': scales,
     }, tooltipScene, view));


### PR DESCRIPTION
Tooltip text generation mode has a api which is difficult to understand, and cannot be customized, unfriendly to users.  This is a simple and user-friendly way to customize the tooltip text.

example:
```dart
...
tooltip: TooltipGuide(
  anchor: (_) => Offset.zero,
  align: Alignment.bottomRight,
  getTooltipText: (vars) => "[${vars['group']}] value: ${vars['value']}",
),
...
```