### PR TITLE
fix analysis warnings

### DIFF
--- a/example/lib/home.dart
+++ b/example/lib/home.dart
@@ -25,8 +25,8 @@ class PageCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final TextStyle titleStyle = theme.textTheme.headline6!;
-    final TextStyle descriptionStyle = theme.textTheme.bodyText2!;
+    final TextStyle titleStyle = theme.textTheme.titleLarge!;
+    final TextStyle descriptionStyle = theme.textTheme.bodyMedium!;
 
     return Container(
         padding: const EdgeInsets.all(4.0),

--- a/example/lib/pages/interaction_stream_dynamic.dart
+++ b/example/lib/pages/interaction_stream_dynamic.dart
@@ -10,7 +10,7 @@ class InteractionStreamDynamicPage extends StatefulWidget {
   const InteractionStreamDynamicPage({Key? key}) : super(key: key);
 
   @override
-  _InteractionStreamDynamicPageState createState() =>
+  State<InteractionStreamDynamicPage> createState() =>
       _InteractionStreamDynamicPageState();
 }
 

--- a/graffiti_dev/lib/graffiti/element/element.dart
+++ b/graffiti_dev/lib/graffiti/element/element.dart
@@ -79,17 +79,9 @@ class PaintStyle extends ElementStyle {
     Color? shadowColor,
     this.dash,
     this.dashOffset,
-  })  : assert(
-            isSingle([fillColor, fillGradient, fillShader], allowNone: true)),
-        assert(isSingle([strokeColor, strokeGradient, strokeShader],
-            allowNone: true)),
-        assert(strokeColor != null ||
-            strokeGradient != null ||
-            strokeShader != null ||
-            (strokeWidth == null ||
-                strokeCap == null ||
-                strokeJoin == null ||
-                strokeMiterLimit == null)),
+  })  : assert(isSingle([fillColor, fillGradient, fillShader], allowNone: true)),
+        assert(isSingle([strokeColor, strokeGradient, strokeShader], allowNone: true)),
+        assert(strokeColor != null || strokeGradient != null || strokeShader != null || (strokeWidth == null || strokeCap == null || strokeJoin == null || strokeMiterLimit == null)),
         assert(elevation != null || shadowColor == null),
         assert(dash != null || dashOffset == null),
         shadowColor = elevation == null

--- a/graffiti_dev/lib/graffiti/element/element.dart
+++ b/graffiti_dev/lib/graffiti/element/element.dart
@@ -18,6 +18,7 @@ abstract class ElementStyle {
 abstract class MarkElement<S extends ElementStyle> {
   MarkElement({
     required this.style,
+
     this.rotation,
     this.rotationAxis,
   }) : assert(rotation == null || rotationAxis != null);
@@ -111,7 +112,7 @@ class PaintStyle extends ElementStyle {
   final StrokeJoin? strokeJoin;
 
   final double? strokeMiterLimit;
-
+  
   final double? elevation;
 
   final Color? shadowColor;
@@ -122,26 +123,23 @@ class PaintStyle extends ElementStyle {
 
   @override
   PaintStyle lerpFrom(covariant PaintStyle from, double t) => PaintStyle(
-        fillColor: Color.lerp(from.fillColor, fillColor, t),
-        fillGradient:
-            painting.Gradient.lerp(from.fillGradient, fillGradient, t),
-        fillShader: fillShader,
-        strokeColor: Color.lerp(from.strokeColor, strokeColor, t),
-        strokeGradient:
-            painting.Gradient.lerp(from.strokeGradient, strokeGradient, t),
-        strokeShader: strokeShader,
-        gradientBounds: Rect.lerp(from.gradientBounds, gradientBounds, t),
-        blendMode: blendMode,
-        strokeWidth: lerpDouble(from.strokeWidth, strokeWidth, t),
-        strokeCap: strokeCap,
-        strokeJoin: strokeJoin,
-        strokeMiterLimit:
-            lerpDouble(from.strokeMiterLimit, strokeMiterLimit, t),
-        elevation: lerpDouble(from.elevation, elevation, t),
-        shadowColor: Color.lerp(from.shadowColor, shadowColor, t),
-        dash: _lerpDash(from.dash, dash, t),
-        dashOffset: dashOffset,
-      );
+    fillColor: Color.lerp(from.fillColor, fillColor, t),
+    fillGradient: painting.Gradient.lerp(from.fillGradient, fillGradient, t),
+    fillShader: fillShader,
+    strokeColor: Color.lerp(from.strokeColor, strokeColor, t),
+    strokeGradient: painting.Gradient.lerp(from.strokeGradient, strokeGradient, t),
+    strokeShader: strokeShader,
+    gradientBounds: Rect.lerp(from.gradientBounds, gradientBounds, t),
+    blendMode: blendMode,
+    strokeWidth: lerpDouble(from.strokeWidth, strokeWidth, t),
+    strokeCap: strokeCap,
+    strokeJoin: strokeJoin,
+    strokeMiterLimit: lerpDouble(from.strokeMiterLimit, strokeMiterLimit, t),
+    elevation: lerpDouble(from.elevation, elevation, t),
+    shadowColor: Color.lerp(from.shadowColor, shadowColor, t),
+    dash: _lerpDash(from.dash, dash, t),
+    dashOffset: dashOffset,
+  );
 }
 
 final defaultPaintStyle = PaintStyle(strokeColor: const Color(0xff000000));
@@ -149,25 +147,23 @@ final defaultPaintStyle = PaintStyle(strokeColor: const Color(0xff000000));
 abstract class PrimitiveElement extends MarkElement<PaintStyle> {
   PrimitiveElement({
     required PaintStyle style,
+
     double? rotation,
     Offset? rotationAxis,
   }) : super(
-          style: style,
-          rotation: rotation,
-          rotationAxis: rotationAxis,
-        ) {
+    style: style,
+    rotation: rotation,
+    rotationAxis: rotationAxis,
+  ) {
     drawPath(path);
 
-    if (style.fillColor != null ||
-        style.fillGradient != null ||
-        style.fillShader != null) {
+    if (style.fillColor != null || style.fillGradient != null || style.fillShader != null) {
       _fillPaint = Paint();
 
       if (style.fillShader != null) {
         _fillPaint!.shader = style.fillShader;
       } else if (style.fillGradient != null) {
-        _fillPaint!.shader = toUiGradient(
-            style.fillGradient!, style.gradientBounds ?? path.getBounds());
+        _fillPaint!.shader = toUiGradient(style.fillGradient!, style.gradientBounds ?? path.getBounds());
       } else {
         _fillPaint!.color = style.fillColor!;
       }
@@ -183,8 +179,7 @@ abstract class PrimitiveElement extends MarkElement<PaintStyle> {
       if (style.strokeShader != null) {
         _strokePaint!.shader = style.strokeShader;
       } else if (style.strokeGradient != null) {
-        _strokePaint!.shader = toUiGradient(
-            style.strokeGradient!, style.gradientBounds ?? path.getBounds());
+        _strokePaint!.shader = toUiGradient(style.strokeGradient!, style.gradientBounds ?? path.getBounds());
       } else {
         _strokePaint!.color = style.strokeColor!;
       }
@@ -207,9 +202,7 @@ abstract class PrimitiveElement extends MarkElement<PaintStyle> {
     }
 
     if (style.dash != null) {
-      _dathPath = dashPath(path,
-          dashArray: CircularIntervalList(style.dash!),
-          dashOffset: style.dashOffset);
+      _dathPath = dashPath(path, dashArray: CircularIntervalList(style.dash!), dashOffset: style.dashOffset);
     }
   }
 
@@ -281,12 +274,13 @@ abstract class BlockElement<S extends BlockStyle> extends MarkElement<S> {
   BlockElement({
     required this.anchor,
     required this.defaultAlign,
+
     required S style,
   }) : super(
-          style: style,
-          rotation: style.rotation,
-          rotationAxis: style.offset == null ? anchor : anchor + style.offset!,
-        );
+    style: style,
+    rotation: style.rotation,
+    rotationAxis: style.offset == null ? anchor : anchor + style.offset!,
+  );
 
   final Offset anchor;
 
@@ -300,16 +294,8 @@ abstract class BlockElement<S extends BlockStyle> extends MarkElement<S> {
 List<PathElement> _nomalizeShape(PrimitiveElement from, PrimitiveElement to) {
   final segmentsPair = nomalizeSegments(from.toSegments(), to.toSegments());
   return [
-    PathElement(
-        segments: segmentsPair.first,
-        style: from.style,
-        rotation: from.rotation,
-        rotationAxis: from.rotationAxis),
-    PathElement(
-        segments: segmentsPair.last,
-        style: to.style,
-        rotation: to.rotation,
-        rotationAxis: to.rotationAxis),
+    PathElement(segments: segmentsPair.first, style: from.style, rotation: from.rotation, rotationAxis: from.rotationAxis),
+    PathElement(segments: segmentsPair.last, style: to.style, rotation: to.rotation, rotationAxis: to.rotationAxis),
   ];
 }
 
@@ -317,14 +303,8 @@ List<MarkElement> nomalizeElement(MarkElement from, MarkElement to) {
   if (from is GroupElement && to is GroupElement) {
     final elementsPair = nomalizeElementList(from.elements, to.elements);
     return [
-      GroupElement(
-          elements: elementsPair.first,
-          rotation: from.rotation,
-          rotationAxis: from.rotationAxis),
-      GroupElement(
-          elements: elementsPair.last,
-          rotation: to.rotation,
-          rotationAxis: to.rotationAxis),
+      GroupElement(elements: elementsPair.first, rotation: from.rotation, rotationAxis: from.rotationAxis),
+      GroupElement(elements: elementsPair.last, rotation: to.rotation, rotationAxis: to.rotationAxis),
     ];
   }
 
@@ -344,8 +324,7 @@ List<MarkElement> nomalizeElement(MarkElement from, MarkElement to) {
   return [to, to];
 }
 
-List<List<MarkElement>> nomalizeElementList(
-    List<MarkElement> from, List<MarkElement> to) {
+List<List<MarkElement>> nomalizeElementList(List<MarkElement> from, List<MarkElement> to) {
   final fromRst = <MarkElement>[];
   final toRst = <MarkElement>[];
   assert(from.length == to.length);

--- a/graffiti_dev/lib/graffiti/element/element.dart
+++ b/graffiti_dev/lib/graffiti/element/element.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart' as painting;
 
 import 'package:path_drawing/path_drawing.dart';
+// ignore: implementation_imports
 import 'package:graphic/src/util/assert.dart';
 
 import '../util/gradient.dart';
@@ -17,7 +18,6 @@ abstract class ElementStyle {
 abstract class MarkElement<S extends ElementStyle> {
   MarkElement({
     required this.style,
-
     this.rotation,
     this.rotationAxis,
   }) : assert(rotation == null || rotationAxis != null);
@@ -79,14 +79,22 @@ class PaintStyle extends ElementStyle {
     Color? shadowColor,
     this.dash,
     this.dashOffset,
-  }) : assert(isSingle([fillColor, fillGradient, fillShader], allowNone: true)),
-       assert(isSingle([strokeColor, strokeGradient, strokeShader], allowNone: true)),
-       assert(strokeColor != null || strokeGradient != null || strokeShader != null || (strokeWidth == null || strokeCap == null || strokeJoin == null || strokeMiterLimit == null)),
-       assert(elevation != null || shadowColor == null),
-       assert(dash != null || dashOffset == null),
-       shadowColor = elevation == null
-        ? null
-        : fillColor ?? (strokeColor ?? const Color(0xFF000000));
+  })  : assert(
+            isSingle([fillColor, fillGradient, fillShader], allowNone: true)),
+        assert(isSingle([strokeColor, strokeGradient, strokeShader],
+            allowNone: true)),
+        assert(strokeColor != null ||
+            strokeGradient != null ||
+            strokeShader != null ||
+            (strokeWidth == null ||
+                strokeCap == null ||
+                strokeJoin == null ||
+                strokeMiterLimit == null)),
+        assert(elevation != null || shadowColor == null),
+        assert(dash != null || dashOffset == null),
+        shadowColor = elevation == null
+            ? null
+            : fillColor ?? (strokeColor ?? const Color(0xFF000000));
 
   final Color? fillColor;
 
@@ -111,7 +119,7 @@ class PaintStyle extends ElementStyle {
   final StrokeJoin? strokeJoin;
 
   final double? strokeMiterLimit;
-  
+
   final double? elevation;
 
   final Color? shadowColor;
@@ -122,23 +130,26 @@ class PaintStyle extends ElementStyle {
 
   @override
   PaintStyle lerpFrom(covariant PaintStyle from, double t) => PaintStyle(
-    fillColor: Color.lerp(from.fillColor, fillColor, t),
-    fillGradient: painting.Gradient.lerp(from.fillGradient, fillGradient, t),
-    fillShader: fillShader,
-    strokeColor: Color.lerp(from.strokeColor, strokeColor, t),
-    strokeGradient: painting.Gradient.lerp(from.strokeGradient, strokeGradient, t),
-    strokeShader: strokeShader,
-    gradientBounds: Rect.lerp(from.gradientBounds, gradientBounds, t),
-    blendMode: blendMode,
-    strokeWidth: lerpDouble(from.strokeWidth, strokeWidth, t),
-    strokeCap: strokeCap,
-    strokeJoin: strokeJoin,
-    strokeMiterLimit: lerpDouble(from.strokeMiterLimit, strokeMiterLimit, t),
-    elevation: lerpDouble(from.elevation, elevation, t),
-    shadowColor: Color.lerp(from.shadowColor, shadowColor, t),
-    dash: _lerpDash(from.dash, dash, t),
-    dashOffset: dashOffset,
-  );
+        fillColor: Color.lerp(from.fillColor, fillColor, t),
+        fillGradient:
+            painting.Gradient.lerp(from.fillGradient, fillGradient, t),
+        fillShader: fillShader,
+        strokeColor: Color.lerp(from.strokeColor, strokeColor, t),
+        strokeGradient:
+            painting.Gradient.lerp(from.strokeGradient, strokeGradient, t),
+        strokeShader: strokeShader,
+        gradientBounds: Rect.lerp(from.gradientBounds, gradientBounds, t),
+        blendMode: blendMode,
+        strokeWidth: lerpDouble(from.strokeWidth, strokeWidth, t),
+        strokeCap: strokeCap,
+        strokeJoin: strokeJoin,
+        strokeMiterLimit:
+            lerpDouble(from.strokeMiterLimit, strokeMiterLimit, t),
+        elevation: lerpDouble(from.elevation, elevation, t),
+        shadowColor: Color.lerp(from.shadowColor, shadowColor, t),
+        dash: _lerpDash(from.dash, dash, t),
+        dashOffset: dashOffset,
+      );
 }
 
 final defaultPaintStyle = PaintStyle(strokeColor: const Color(0xff000000));
@@ -146,23 +157,25 @@ final defaultPaintStyle = PaintStyle(strokeColor: const Color(0xff000000));
 abstract class PrimitiveElement extends MarkElement<PaintStyle> {
   PrimitiveElement({
     required PaintStyle style,
-
     double? rotation,
     Offset? rotationAxis,
   }) : super(
-    style: style,
-    rotation: rotation,
-    rotationAxis: rotationAxis,
-  ) {
+          style: style,
+          rotation: rotation,
+          rotationAxis: rotationAxis,
+        ) {
     drawPath(path);
 
-    if (style.fillColor != null || style.fillGradient != null || style.fillShader != null) {
+    if (style.fillColor != null ||
+        style.fillGradient != null ||
+        style.fillShader != null) {
       _fillPaint = Paint();
 
       if (style.fillShader != null) {
         _fillPaint!.shader = style.fillShader;
       } else if (style.fillGradient != null) {
-        _fillPaint!.shader = toUiGradient(style.fillGradient!, style.gradientBounds ?? path.getBounds());
+        _fillPaint!.shader = toUiGradient(
+            style.fillGradient!, style.gradientBounds ?? path.getBounds());
       } else {
         _fillPaint!.color = style.fillColor!;
       }
@@ -178,7 +191,8 @@ abstract class PrimitiveElement extends MarkElement<PaintStyle> {
       if (style.strokeShader != null) {
         _strokePaint!.shader = style.strokeShader;
       } else if (style.strokeGradient != null) {
-        _strokePaint!.shader = toUiGradient(style.strokeGradient!, style.gradientBounds ?? path.getBounds());
+        _strokePaint!.shader = toUiGradient(
+            style.strokeGradient!, style.gradientBounds ?? path.getBounds());
       } else {
         _strokePaint!.color = style.strokeColor!;
       }
@@ -201,7 +215,9 @@ abstract class PrimitiveElement extends MarkElement<PaintStyle> {
     }
 
     if (style.dash != null) {
-      _dathPath = dashPath(path, dashArray: CircularIntervalList(style.dash!), dashOffset: style.dashOffset);
+      _dathPath = dashPath(path,
+          dashArray: CircularIntervalList(style.dash!),
+          dashOffset: style.dashOffset);
     }
   }
 
@@ -273,13 +289,12 @@ abstract class BlockElement<S extends BlockStyle> extends MarkElement<S> {
   BlockElement({
     required this.anchor,
     required this.defaultAlign,
-
     required S style,
   }) : super(
-    style: style,
-    rotation: style.rotation,
-    rotationAxis: style.offset == null ? anchor : anchor + style.offset!,
-  );
+          style: style,
+          rotation: style.rotation,
+          rotationAxis: style.offset == null ? anchor : anchor + style.offset!,
+        );
 
   final Offset anchor;
 
@@ -293,8 +308,16 @@ abstract class BlockElement<S extends BlockStyle> extends MarkElement<S> {
 List<PathElement> _nomalizeShape(PrimitiveElement from, PrimitiveElement to) {
   final segmentsPair = nomalizeSegments(from.toSegments(), to.toSegments());
   return [
-    PathElement(segments: segmentsPair.first, style: from.style, rotation: from.rotation, rotationAxis: from.rotationAxis),
-    PathElement(segments: segmentsPair.last, style: to.style, rotation: to.rotation, rotationAxis: to.rotationAxis),
+    PathElement(
+        segments: segmentsPair.first,
+        style: from.style,
+        rotation: from.rotation,
+        rotationAxis: from.rotationAxis),
+    PathElement(
+        segments: segmentsPair.last,
+        style: to.style,
+        rotation: to.rotation,
+        rotationAxis: to.rotationAxis),
   ];
 }
 
@@ -302,8 +325,14 @@ List<MarkElement> nomalizeElement(MarkElement from, MarkElement to) {
   if (from is GroupElement && to is GroupElement) {
     final elementsPair = nomalizeElementList(from.elements, to.elements);
     return [
-      GroupElement(elements: elementsPair.first, rotation: from.rotation, rotationAxis: from.rotationAxis),
-      GroupElement(elements: elementsPair.last, rotation: to.rotation, rotationAxis: to.rotationAxis),
+      GroupElement(
+          elements: elementsPair.first,
+          rotation: from.rotation,
+          rotationAxis: from.rotationAxis),
+      GroupElement(
+          elements: elementsPair.last,
+          rotation: to.rotation,
+          rotationAxis: to.rotationAxis),
     ];
   }
 
@@ -323,7 +352,8 @@ List<MarkElement> nomalizeElement(MarkElement from, MarkElement to) {
   return [to, to];
 }
 
-List<List<MarkElement>> nomalizeElementList(List<MarkElement> from, List<MarkElement> to) {
+List<List<MarkElement>> nomalizeElementList(
+    List<MarkElement> from, List<MarkElement> to) {
   final fromRst = <MarkElement>[];
   final toRst = <MarkElement>[];
   assert(from.length == to.length);

--- a/graffiti_dev/lib/graffiti/element/element.dart
+++ b/graffiti_dev/lib/graffiti/element/element.dart
@@ -79,14 +79,14 @@ class PaintStyle extends ElementStyle {
     Color? shadowColor,
     this.dash,
     this.dashOffset,
-  })  : assert(isSingle([fillColor, fillGradient, fillShader], allowNone: true)),
-        assert(isSingle([strokeColor, strokeGradient, strokeShader], allowNone: true)),
-        assert(strokeColor != null || strokeGradient != null || strokeShader != null || (strokeWidth == null || strokeCap == null || strokeJoin == null || strokeMiterLimit == null)),
-        assert(elevation != null || shadowColor == null),
-        assert(dash != null || dashOffset == null),
-        shadowColor = elevation == null
-            ? null
-            : fillColor ?? (strokeColor ?? const Color(0xFF000000));
+  }) : assert(isSingle([fillColor, fillGradient, fillShader], allowNone: true)),
+       assert(isSingle([strokeColor, strokeGradient, strokeShader], allowNone: true)),
+       assert(strokeColor != null || strokeGradient != null || strokeShader != null || (strokeWidth == null || strokeCap == null || strokeJoin == null || strokeMiterLimit == null)),
+       assert(elevation != null || shadowColor == null),
+       assert(dash != null || dashOffset == null),
+       shadowColor = elevation == null
+        ? null
+        : fillColor ?? (strokeColor ?? const Color(0xFF000000));
 
   final Color? fillColor;
 

--- a/graffiti_dev/lib/graffiti/element/image.dart
+++ b/graffiti_dev/lib/graffiti/element/image.dart
@@ -44,7 +44,8 @@ class ImageElement extends BlockElement<ImageStyle> {
     defaultAlign: defaultAlign ?? Alignment.center,
     style: style ?? _defaultImageStyle,
   ) {
-    paintPoint = getPaintPoint(rotationAxis!, image.width.toDouble(), image.height.toDouble(), this.style.align ?? this.defaultAlign); // TODO: Image width height pixel ratio.
+    // TODO: Image width height pixel ratio
+    paintPoint = getPaintPoint(rotationAxis!, image.width.toDouble(), image.height.toDouble(), this.style.align ?? this.defaultAlign);
   }
 
   final Image image;

--- a/graffiti_dev/lib/graffiti/element/label.dart
+++ b/graffiti_dev/lib/graffiti/element/label.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/painting.dart';
 
+// ignore: implementation_imports
 import 'package:graphic/src/util/assert.dart';
 
 import 'element.dart';
@@ -22,16 +23,15 @@ class LabelStyle extends BlockStyle {
     this.textHeightBehavior,
     this.minWidth,
     this.maxWidth,
-
     Offset? offset,
     double? rotation,
     Alignment? align,
-  }) : assert(isSingle([textStyle, span])),
-       super(
-         offset: offset,
-         rotation: rotation,
-         align: align,
-       );
+  })  : assert(isSingle([textStyle, span])),
+        super(
+          offset: offset,
+          rotation: rotation,
+          align: align,
+        );
 
   /// The text style of the label.
   ///
@@ -130,20 +130,19 @@ class LabelStyle extends BlockStyle {
 
   @override
   LabelStyle lerpFrom(covariant LabelStyle from, double t) => LabelStyle(
-    textStyle: TextStyle.lerp(from.textStyle, textStyle, t),
-    span: span,
-    textAlign: textAlign,
-    textDirection: textDirection,
-    textScaleFactor: lerpDouble(from.textScaleFactor, textScaleFactor, t),
-    maxLines: lerpDouble(from.maxLines, maxLines, t)?.toInt(),
-    ellipsis: ellipsis,
-    locale: locale,
-    strutStyle: strutStyle,
-    textWidthBasis: textWidthBasis,
-    textHeightBehavior: textHeightBehavior,
-    minWidth: lerpDouble(from.minWidth, minWidth, t),
-    maxWidth: lerpDouble(from.maxWidth, maxWidth, t)
-  );
+      textStyle: TextStyle.lerp(from.textStyle, textStyle, t),
+      span: span,
+      textAlign: textAlign,
+      textDirection: textDirection,
+      textScaleFactor: lerpDouble(from.textScaleFactor, textScaleFactor, t),
+      maxLines: lerpDouble(from.maxLines, maxLines, t)?.toInt(),
+      ellipsis: ellipsis,
+      locale: locale,
+      strutStyle: strutStyle,
+      textWidthBasis: textWidthBasis,
+      textHeightBehavior: textHeightBehavior,
+      minWidth: lerpDouble(from.minWidth, minWidth, t),
+      maxWidth: lerpDouble(from.maxWidth, maxWidth, t));
 }
 
 final _defaultLabelStyle = LabelStyle();
@@ -151,15 +150,14 @@ final _defaultLabelStyle = LabelStyle();
 class LabelElement extends BlockElement<LabelStyle> {
   LabelElement({
     required this.text,
-
     required Offset anchor,
     Alignment? defaultAlign,
     LabelStyle? style,
   }) : super(
-    anchor: anchor,
-    defaultAlign: defaultAlign ?? Alignment.center,
-    style: style ?? _defaultLabelStyle,
-  ) {
+          anchor: anchor,
+          defaultAlign: defaultAlign ?? Alignment.center,
+          style: style ?? _defaultLabelStyle,
+        ) {
     _painter = TextPainter(
       text: this.style.textStyle != null
           ? TextSpan(text: text, style: this.style.textStyle)
@@ -179,22 +177,22 @@ class LabelElement extends BlockElement<LabelStyle> {
       maxWidth: this.style.maxWidth ?? double.infinity,
     );
 
-    paintPoint = getPaintPoint(rotationAxis!, _painter.width, _painter.height, this.style.align ?? this.defaultAlign);
+    paintPoint = getPaintPoint(rotationAxis!, _painter.width, _painter.height,
+        this.style.align ?? this.defaultAlign);
   }
 
   final String text;
 
   late final TextPainter _painter;
-  
+
   @override
-  void draw(Canvas canvas) =>
-    _painter.paint(canvas, paintPoint);
-    
+  void draw(Canvas canvas) => _painter.paint(canvas, paintPoint);
+
   @override
   LabelElement lerpFrom(covariant LabelElement from, double t) => LabelElement(
-    text: text,
-    anchor: Offset.lerp(from.anchor, anchor, t)!,
-    defaultAlign: Alignment.lerp(from.defaultAlign, defaultAlign, t)!,
-    style: style.lerpFrom(from.style, t),
-  );
+        text: text,
+        anchor: Offset.lerp(from.anchor, anchor, t)!,
+        defaultAlign: Alignment.lerp(from.defaultAlign, defaultAlign, t)!,
+        style: style.lerpFrom(from.style, t),
+      );
 }

--- a/graffiti_dev/lib/graffiti/element/label.dart
+++ b/graffiti_dev/lib/graffiti/element/label.dart
@@ -23,15 +23,16 @@ class LabelStyle extends BlockStyle {
     this.textHeightBehavior,
     this.minWidth,
     this.maxWidth,
+
     Offset? offset,
     double? rotation,
     Alignment? align,
-  })  : assert(isSingle([textStyle, span])),
-        super(
-          offset: offset,
-          rotation: rotation,
-          align: align,
-        );
+  }) : assert(isSingle([textStyle, span])),
+       super(
+         offset: offset,
+         rotation: rotation,
+         align: align,
+       );
 
   /// The text style of the label.
   ///
@@ -130,19 +131,20 @@ class LabelStyle extends BlockStyle {
 
   @override
   LabelStyle lerpFrom(covariant LabelStyle from, double t) => LabelStyle(
-      textStyle: TextStyle.lerp(from.textStyle, textStyle, t),
-      span: span,
-      textAlign: textAlign,
-      textDirection: textDirection,
-      textScaleFactor: lerpDouble(from.textScaleFactor, textScaleFactor, t),
-      maxLines: lerpDouble(from.maxLines, maxLines, t)?.toInt(),
-      ellipsis: ellipsis,
-      locale: locale,
-      strutStyle: strutStyle,
-      textWidthBasis: textWidthBasis,
-      textHeightBehavior: textHeightBehavior,
-      minWidth: lerpDouble(from.minWidth, minWidth, t),
-      maxWidth: lerpDouble(from.maxWidth, maxWidth, t));
+    textStyle: TextStyle.lerp(from.textStyle, textStyle, t),
+    span: span,
+    textAlign: textAlign,
+    textDirection: textDirection,
+    textScaleFactor: lerpDouble(from.textScaleFactor, textScaleFactor, t),
+    maxLines: lerpDouble(from.maxLines, maxLines, t)?.toInt(),
+    ellipsis: ellipsis,
+    locale: locale,
+    strutStyle: strutStyle,
+    textWidthBasis: textWidthBasis,
+    textHeightBehavior: textHeightBehavior,
+    minWidth: lerpDouble(from.minWidth, minWidth, t),
+    maxWidth: lerpDouble(from.maxWidth, maxWidth, t)
+  );
 }
 
 final _defaultLabelStyle = LabelStyle();
@@ -150,14 +152,15 @@ final _defaultLabelStyle = LabelStyle();
 class LabelElement extends BlockElement<LabelStyle> {
   LabelElement({
     required this.text,
+
     required Offset anchor,
     Alignment? defaultAlign,
     LabelStyle? style,
   }) : super(
-          anchor: anchor,
-          defaultAlign: defaultAlign ?? Alignment.center,
-          style: style ?? _defaultLabelStyle,
-        ) {
+    anchor: anchor,
+    defaultAlign: defaultAlign ?? Alignment.center,
+    style: style ?? _defaultLabelStyle,
+  ) {
     _painter = TextPainter(
       text: this.style.textStyle != null
           ? TextSpan(text: text, style: this.style.textStyle)
@@ -177,22 +180,22 @@ class LabelElement extends BlockElement<LabelStyle> {
       maxWidth: this.style.maxWidth ?? double.infinity,
     );
 
-    paintPoint = getPaintPoint(rotationAxis!, _painter.width, _painter.height,
-        this.style.align ?? this.defaultAlign);
+    paintPoint = getPaintPoint(rotationAxis!, _painter.width, _painter.height, this.style.align ?? this.defaultAlign);
   }
 
   final String text;
 
   late final TextPainter _painter;
-
+  
   @override
-  void draw(Canvas canvas) => _painter.paint(canvas, paintPoint);
-
+  void draw(Canvas canvas) =>
+    _painter.paint(canvas, paintPoint);
+    
   @override
   LabelElement lerpFrom(covariant LabelElement from, double t) => LabelElement(
-        text: text,
-        anchor: Offset.lerp(from.anchor, anchor, t)!,
-        defaultAlign: Alignment.lerp(from.defaultAlign, defaultAlign, t)!,
-        style: style.lerpFrom(from.style, t),
-      );
+    text: text,
+    anchor: Offset.lerp(from.anchor, anchor, t)!,
+    defaultAlign: Alignment.lerp(from.defaultAlign, defaultAlign, t)!,
+    style: style.lerpFrom(from.style, t),
+  );
 }

--- a/graffiti_dev/lib/graffiti/element/sector.dart
+++ b/graffiti_dev/lib/graffiti/element/sector.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/painting.dart';
 import 'package:graffiti_dev/graffiti/element/segment/arc.dart';
 
+// ignore: implementation_imports
 import 'package:graphic/src/util/math.dart';
 
 import 'element.dart';

--- a/graffiti_dev/lib/graffiti/scene.dart
+++ b/graffiti_dev/lib/graffiti/scene.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:flutter/animation.dart';
 
 import 'element/element.dart';
-import 'graffiti.dart';
 import 'transition.dart';
 
 class Scene {
@@ -17,13 +16,17 @@ class Scene {
     if (transition == null) {
       _controller = null;
     } else {
-      _controller = AnimationController(vsync: tickerProvider, duration: transition!.duration);
-      final animation = transition!.curve == null ? _controller! : CurvedAnimation(parent: _controller!, curve: transition!.curve!);
+      _controller = AnimationController(
+          vsync: tickerProvider, duration: transition!.duration);
+      final animation = transition!.curve == null
+          ? _controller!
+          : CurvedAnimation(parent: _controller!, curve: transition!.curve!);
       animation.addListener(() {
         if (_animateElements) {
           _elements = [];
           for (var i = 0; i < _endElements!.length; i++) {
-            _elements!.add(_endElements![i].lerpFrom(_startElements![i], animation.value));
+            _elements!.add(
+                _endElements![i].lerpFrom(_startElements![i], animation.value));
           }
         }
 
@@ -85,7 +88,8 @@ class Scene {
   late bool _animateClip;
 
   void set(List<MarkElement>? elements, [PrimitiveElement? clip]) {
-    _animateElements = _controller != null && _currentElements != null && elements != null;
+    _animateElements =
+        _controller != null && _currentElements != null && elements != null;
     _animateClip = _controller != null && _currentClip != null && clip != null;
 
     _preElements = _currentElements;
@@ -103,7 +107,8 @@ class Scene {
 
   void update() {
     if (_animateElements) {
-      final elementsPair = nomalizeElementList(_preElements!, _currentElements!);
+      final elementsPair =
+          nomalizeElementList(_preElements!, _currentElements!);
       _startElements = elementsPair.first;
       _endElements = elementsPair.last;
     }
@@ -129,7 +134,7 @@ class Scene {
   void paint(Canvas canvas) {
     if (_elements != null) {
       canvas.save();
-      
+
       if (_clip != null) {
         if (_clip!.rotation == null) {
           canvas.clipPath(_clip!.path);

--- a/graffiti_dev/lib/graffiti/scene.dart
+++ b/graffiti_dev/lib/graffiti/scene.dart
@@ -16,17 +16,13 @@ class Scene {
     if (transition == null) {
       _controller = null;
     } else {
-      _controller = AnimationController(
-          vsync: tickerProvider, duration: transition!.duration);
-      final animation = transition!.curve == null
-          ? _controller!
-          : CurvedAnimation(parent: _controller!, curve: transition!.curve!);
+      _controller = AnimationController(vsync: tickerProvider, duration: transition!.duration);
+      final animation = transition!.curve == null ? _controller! : CurvedAnimation(parent: _controller!, curve: transition!.curve!);
       animation.addListener(() {
         if (_animateElements) {
           _elements = [];
           for (var i = 0; i < _endElements!.length; i++) {
-            _elements!.add(
-                _endElements![i].lerpFrom(_startElements![i], animation.value));
+            _elements!.add(_endElements![i].lerpFrom(_startElements![i], animation.value));
           }
         }
 
@@ -88,8 +84,7 @@ class Scene {
   late bool _animateClip;
 
   void set(List<MarkElement>? elements, [PrimitiveElement? clip]) {
-    _animateElements =
-        _controller != null && _currentElements != null && elements != null;
+    _animateElements = _controller != null && _currentElements != null && elements != null;
     _animateClip = _controller != null && _currentClip != null && clip != null;
 
     _preElements = _currentElements;
@@ -107,8 +102,7 @@ class Scene {
 
   void update() {
     if (_animateElements) {
-      final elementsPair =
-          nomalizeElementList(_preElements!, _currentElements!);
+      final elementsPair = nomalizeElementList(_preElements!, _currentElements!);
       _startElements = elementsPair.first;
       _endElements = elementsPair.last;
     }
@@ -134,7 +128,7 @@ class Scene {
   void paint(Canvas canvas) {
     if (_elements != null) {
       canvas.save();
-
+      
       if (_clip != null) {
         if (_clip!.rotation == null) {
           canvas.clipPath(_clip!.path);

--- a/graffiti_dev/lib/home.dart
+++ b/graffiti_dev/lib/home.dart
@@ -25,8 +25,8 @@ class PageCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final TextStyle titleStyle = theme.textTheme.headline6!;
-    final TextStyle descriptionStyle = theme.textTheme.bodyText2!;
+    final TextStyle titleStyle = theme.textTheme.titleLarge!;
+    final TextStyle descriptionStyle = theme.textTheme.bodyMedium!;
 
     return Container(
         padding: const EdgeInsets.all(4.0),

--- a/graffiti_dev/lib/pages/shape.dart
+++ b/graffiti_dev/lib/pages/shape.dart
@@ -1,26 +1,8 @@
 import 'dart:math';
 
-import 'package:graffiti_dev/graffiti/element/arc.dart';
 import 'package:graffiti_dev/graffiti/element/circle.dart';
-import 'package:graffiti_dev/graffiti/element/spline.dart';
-import 'package:graffiti_dev/graffiti/element/group.dart';
-import 'package:graffiti_dev/graffiti/element/label.dart';
-import 'package:graffiti_dev/graffiti/element/oval.dart';
-import 'package:graffiti_dev/graffiti/element/path.dart';
-import 'package:graffiti_dev/graffiti/element/polygon.dart';
-import 'package:graffiti_dev/graffiti/element/polyline.dart';
 import 'package:graffiti_dev/graffiti/element/rect.dart';
-import 'package:graffiti_dev/graffiti/element/sector.dart';
-import 'package:graffiti_dev/graffiti/element/segment/arc.dart';
-import 'package:graffiti_dev/graffiti/element/segment/arc_to_point.dart';
-import 'package:graffiti_dev/graffiti/element/segment/close.dart';
-import 'package:graffiti_dev/graffiti/element/segment/conic.dart';
-import 'package:graffiti_dev/graffiti/element/segment/cubic.dart';
-import 'package:graffiti_dev/graffiti/element/segment/line.dart';
-import 'package:graffiti_dev/graffiti/element/segment/move.dart';
-import 'package:graffiti_dev/graffiti/element/segment/quadratic.dart';
 import 'package:graffiti_dev/graffiti/graffiti.dart';
-import 'package:graffiti_dev/graffiti/element/line.dart';
 import 'package:graffiti_dev/graffiti/element/element.dart';
 import 'package:flutter/material.dart';
 import 'package:graffiti_dev/graffiti/scene.dart';
@@ -73,7 +55,7 @@ class _ShapePageState extends State<ShapePage> with SingleTickerProviderStateMix
   void initState() {
     graffiti = Graffiti(tickerProvider: this, repaint: repaint);
 
-    scene = graffiti.createScene(transition: Transition(duration: Duration(seconds: 2)));
+    scene = graffiti.createScene(transition: Transition(duration: const Duration(seconds: 2)));
 
     // final a = SplineElement(start: Offset(10, 10), cubics: [
     //   [Offset(20, 10), Offset(10, 20), Offset(20, 20)],
@@ -147,7 +129,7 @@ class _ShapePageState extends State<ShapePage> with SingleTickerProviderStateMix
 
     // scene.set([ArcElement(oval: Rect.fromPoints(Offset(100, 100), Offset(200, 200)), startAngle: 2, endAngle: 4, style: style)]);
 
-    scene.set([RectElement(rect: Rect.fromPoints(Offset(0, 0), Offset(500, 500)), style: style)], CircleElement(center: Offset(150, 150), radius: 70));
+    scene.set([RectElement(rect: Rect.fromPoints(const Offset(0, 0), const Offset(500, 500)), style: style)], CircleElement(center: const Offset(150, 150), radius: 70));
 
     // scene.set([PolylineElement(points: points1, style: style)], CircleElement(center: Offset(150, 150), radius: 70, style: style));
 
@@ -184,7 +166,7 @@ class _ShapePageState extends State<ShapePage> with SingleTickerProviderStateMix
     // scene.set([PolygonElement(points: points2, style: style)]);
 
     // scene.set([SplineElement(start: Offset(500, 500), cubics: cubics, style: style)], RectElement(rect: Rect.fromPoints(Offset(0, 0), Offset(100, 100)), borderRadius: BorderRadius.all(Radius.circular(5)), style: style));
-    scene.set([RectElement(rect: Rect.fromPoints(Offset(0, 0), Offset(500, 500)), style: style)], RectElement(rect: Rect.fromPoints(Offset(0, 0), Offset(100, 100)), borderRadius: BorderRadius.all(Radius.circular(5))));
+    scene.set([RectElement(rect: Rect.fromPoints(const Offset(0, 0), const Offset(500, 500)), style: style)], RectElement(rect: Rect.fromPoints(const Offset(0, 0), const Offset(100, 100)), borderRadius: const BorderRadius.all(Radius.circular(5))));
     graffiti.update();
   }
 
@@ -200,7 +182,7 @@ class _ShapePageState extends State<ShapePage> with SingleTickerProviderStateMix
         child: Center(
           child: Column(
             children: <Widget>[
-              Container(
+              SizedBox(
                 width: 350,
                 height: 300,
                 child: CustomPaint(painter: _Painter(graffiti)),

--- a/lib/graphic.dart
+++ b/lib/graphic.dart
@@ -150,7 +150,7 @@ export 'src/mark/modifier/jitter.dart' show JitterModifier;
 export 'src/mark/modifier/symmetric.dart' show SymmetricModifier;
 
 export 'src/encode/encode.dart' show Encode;
-export 'src/encode/channel.dart' show StreamEncode;
+export 'src/encode/channel.dart' show ChannelEncode;
 export 'src/encode/color.dart' show ColorEncode;
 export 'src/encode/elevation.dart' show ElevationEncode;
 export 'src/encode/gradient.dart' show GradientEncode;

--- a/lib/src/chart/chart.dart
+++ b/lib/src/chart/chart.dart
@@ -174,7 +174,7 @@ class Chart<D> extends StatefulWidget {
       changeDataStream == other.changeDataStream;
 
   @override
-  _ChartState<D> createState() => _ChartState<D>();
+  State<Chart<D>> createState() => _ChartState<D>();
 }
 
 /// The state of a [Chart].

--- a/lib/src/common/defaults.dart
+++ b/lib/src/common/defaults.dart
@@ -22,7 +22,6 @@ EventUpdater<List<double>> _getRangeUpdate(
 
           if (detail.pointerCount == 1) {
             // Panning.
-
             final deltaRatio = isHorizontal
                 ? gesture.preScaleDetail!.focalPointDelta.dx
                 : -gesture.preScaleDetail!.focalPointDelta.dy;
@@ -33,9 +32,10 @@ EventUpdater<List<double>> _getRangeUpdate(
             return [pre.first + delta, pre.last + delta];
           } else {
             // Scaling.
+            double getScaleDim(ScaleUpdateDetails updateDetails) => isHorizontal 
+                ? updateDetails.horizontalScale 
+                : updateDetails.verticalScale;
 
-            double Function(ScaleUpdateDetails) getScaleDim =
-                (p0) => isHorizontal ? p0.horizontalScale : p0.verticalScale;
             final preScale = getScaleDim(gesture.preScaleDetail!);
             final scale = getScaleDim(detail);
             final deltaRatio = (scale - preScale) / preScale / 2;

--- a/lib/src/coord/coord.dart
+++ b/lib/src/coord/coord.dart
@@ -5,7 +5,6 @@ import 'package:graphic/src/common/dim.dart';
 import 'package:graphic/src/common/intrinsic_layers.dart';
 import 'package:graphic/src/common/operators/render.dart';
 import 'package:graphic/src/dataflow/operator.dart';
-import 'package:graphic/src/dataflow/tuple.dart';
 import 'package:graphic/src/graffiti/scene.dart';
 import 'package:graphic/src/util/assert.dart';
 


### PR DESCRIPTION
The linter throws several warnings about the code base.

This PR resolves all those issues, where the only issue that was simply ignored were the following warnings (in graffiti_dev):
`Import of a library in the 'lib/src' directory of another package. Try importing a public library that exports this library, or removing the import.`

on the following imports:

`import 'package:graphic/src/util/assert.dart';`
`import 'package:graphic/src/util/math.dart';`