### PR TITLE
add keys to gestures, so the sender (owner) can be identified

### DIFF
--- a/lib/src/chart/chart.dart
+++ b/lib/src/chart/chart.dart
@@ -252,6 +252,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onDoubleTapCancel: () {
@@ -261,6 +262,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onDoubleTapDown: (detail) {
@@ -271,6 +273,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onForcePressEnd: (detail) {
@@ -281,6 +284,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onForcePressPeak: (detail) {
@@ -291,6 +295,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onForcePressStart: (detail) {
@@ -301,6 +306,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onForcePressUpdate: (detail) {
@@ -311,6 +317,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onLongPress: () {
@@ -320,6 +327,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onLongPressCancel: () {
@@ -329,6 +337,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onLongPressDown: (detail) {
@@ -339,6 +348,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onLongPressEnd: (detail) {
@@ -350,6 +360,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onLongPressMoveUpdate: (detail) {
@@ -361,6 +372,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 size,
                 detail,
                 localMoveStart: gestureLocalMoveStart,
+                key: widget.key,
               ));
             },
             onLongPressStart: (detail) {
@@ -372,6 +384,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onLongPressUp: () {
@@ -381,18 +394,21 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onScaleEnd: (detail) {
-              gestureLocalMoveStart = null;
-              gestureScaleDetail = null;
               view!.gesture(Gesture(
                 GestureType.scaleEnd,
                 gestureKind,
                 gestureLocalPosition,
                 size,
                 detail,
+                localMoveStart: gestureLocalMoveStart,
+                key: widget.key,
               ));
+              gestureLocalMoveStart = null;
+              gestureScaleDetail = null;
             },
             onScaleStart: (detail) {
               gestureLocalPosition = detail.localFocalPoint;
@@ -410,6 +426,8 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                localMoveStart: gestureLocalMoveStart,
+                key: widget.key,
               ));
             },
             onScaleUpdate: (detail) {
@@ -422,6 +440,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 detail,
                 localMoveStart: gestureLocalMoveStart,
                 preScaleDetail: gestureScaleDetail,
+                key: widget.key,
               ));
               gestureScaleDetail = detail;
             },
@@ -432,6 +451,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onSecondaryLongPressCancel: () {
@@ -441,6 +461,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onSecondaryLongPressDown: (detail) {
@@ -451,6 +472,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onSecondaryLongPressEnd: (detail) {
@@ -462,6 +484,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onSecondaryLongPressMoveUpdate: (detail) {
@@ -473,6 +496,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 size,
                 detail,
                 localMoveStart: gestureLocalMoveStart,
+                key: widget.key,
               ));
             },
             onSecondaryLongPressStart: (detail) {
@@ -484,6 +508,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onSecondaryLongPressUp: () {
@@ -493,6 +518,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onSecondaryTap: () {
@@ -502,6 +528,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onSecondaryTapCancel: () {
@@ -511,6 +538,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onSecondaryTapDown: (detail) {
@@ -521,6 +549,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onSecondaryTapUp: (detail) {
@@ -531,6 +560,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onTap: () {
@@ -540,6 +570,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onTapCancel: () {
@@ -549,6 +580,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onTapDown: (detail) {
@@ -559,6 +591,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onTapUp: (detail) {
@@ -569,6 +602,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onTertiaryLongPress: () {
@@ -578,6 +612,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onTertiaryLongPressCancel: () {
@@ -587,6 +622,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onTertiaryLongPressDown: (detail) {
@@ -597,6 +633,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onTertiaryLongPressEnd: (detail) {
@@ -608,6 +645,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onTertiaryLongPressMoveUpdate: (detail) {
@@ -619,6 +657,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 size,
                 detail,
                 localMoveStart: gestureLocalMoveStart,
+                key: widget.key,
               ));
             },
             onTertiaryLongPressStart: (detail) {
@@ -630,6 +669,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onTertiaryLongPressUp: () {
@@ -639,6 +679,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onTertiaryTapCancel: () {
@@ -648,6 +689,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 null,
+                key: widget.key,
               ));
             },
             onTertiaryTapDown: (detail) {
@@ -658,6 +700,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
             onTertiaryTapUp: (detail) {
@@ -668,6 +711,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 detail,
+                key: widget.key,
               ));
             },
           ),
@@ -680,6 +724,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
               gestureLocalPosition,
               size,
               null,
+              key: widget.key,
             ));
           },
           onPointerSignal: (event) {
@@ -691,6 +736,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
                 gestureLocalPosition,
                 size,
                 event.scrollDelta,
+                key: widget.key,
               ));
             }
           },
@@ -704,6 +750,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
             gestureLocalPosition,
             size,
             null,
+            key: widget.key,
           ));
         },
         onExit: (event) {
@@ -715,6 +762,7 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
             gestureLocalPosition,
             size,
             null,
+            key: widget.key,
           ));
         },
       ),

--- a/lib/src/graffiti/element/segment/segment.dart
+++ b/lib/src/graffiti/element/segment/segment.dart
@@ -7,7 +7,7 @@ import '../path.dart';
 import '../element.dart';
 
 /// Built-in segment tags.
-/// 
+///
 /// Built-in elements use these tags to optimize morphing.
 abstract class SegmentTags {
   static const topLeft = 'topLeft';
@@ -28,7 +28,7 @@ abstract class Segment {
   });
 
   /// The tag to indicate correspondence of this segment in animation.
-  /// 
+  ///
   /// The order and connecting relations of items in a segment list is important,
   /// which is different to [MarkElement] list. So to make a best morphing, two
   /// path segments should:
@@ -44,9 +44,9 @@ abstract class Segment {
   Segment lerpFrom(covariant Segment from, double t);
 
   /// Converts this segment to a [CubicSegment].
-  /// 
+  ///
   /// This method is used for morphing.
-  /// 
+  ///
   /// The algrithoms are from https://github.com/thednp/svg-path-commander 2.0.2
   CubicSegment toCubic(Offset start);
 
@@ -61,7 +61,7 @@ abstract class Segment {
 }
 
 /// A [segment] and its [start]ing point.
-/// 
+///
 /// This is used for [Segment.toCubic] in morphing.
 class SegmentInfo<S extends Segment> {
   /// Creates a segment info.
@@ -75,7 +75,7 @@ class SegmentInfo<S extends Segment> {
 }
 
 /// Splites a path segments into contours.
-/// 
+///
 /// A contour is a continuous path that starts with a [MoveSegment] but dosen't
 /// include other [MoveSegment]s in the middle.
 List<List<Segment>> _spliteContours(List<Segment> segments) {
@@ -95,7 +95,7 @@ List<List<Segment>> _spliteContours(List<Segment> segments) {
 }
 
 /// Complements the [shorter]’s contours count to the [longer].
-/// 
+///
 /// The complementing contours are at the end with a single [MoveSegment].
 List<List<Segment>> _complementContours(
     List<List<Segment>> shorter, List<List<Segment>> longer) {
@@ -127,9 +127,9 @@ List<SegmentInfo> _getContourInfos(List<Segment> contour) {
 }
 
 /// Complements [SegmentInfo]s of [shorter] contour to [longer].
-/// 
+///
 /// The complemention is mainly according to tags.
-/// 
+///
 /// Every item in [shorter] will be kept.
 List<SegmentInfo> _complementInfos(
     List<SegmentInfo> shorter, List<SegmentInfo> longer) {
@@ -167,7 +167,7 @@ List<SegmentInfo> _complementInfos(
 }
 
 /// Normalizes two path segments into same length and same corresponding segment types.
-/// 
+///
 /// Returns a pair of two path results: \[fromRst, toRst\].
 List<List<Segment>> nomalizeSegments(List<Segment> from, List<Segment> to) {
   var fromContours = _spliteContours(from);
@@ -213,7 +213,7 @@ List<List<Segment>> nomalizeSegments(List<Segment> from, List<Segment> to) {
 }
 
 /// Linearly interpolate between two path segments.
-/// 
+///
 /// Make sure the two path segments are nomalized.
 List<Segment> lerpSegments(List<Segment> from, List<Segment> to, double t) {
   final rst = <Segment>[];

--- a/lib/src/interaction/gesture.dart
+++ b/lib/src/interaction/gesture.dart
@@ -511,6 +511,7 @@ class Gesture {
     this.localPosition,
     this.chartSize,
     this.details, {
+    this.key,
     this.localMoveStart,
     this.preScaleDetail,
   });
@@ -534,6 +535,11 @@ class Gesture {
   /// They may be different class types or null according to [type] (See corresponding
   /// relations in [GestureType]).
   final dynamic details;
+
+  /// The key of the emitting chart.
+  ///
+  /// The key may be null, e.g. if the gesture is manually created.
+  final Key? key;
 
   /// The local position of pointer when a scale or long press starts.
   ///

--- a/lib/src/parse/parse.dart
+++ b/lib/src/parse/parse.dart
@@ -109,7 +109,8 @@ void parse<D>(
 
   if (coordSpec.color != null) {
     final regionBackgroundScene = view.graffiti.createScene(
-        layer: coordSpec.layer ?? 0, builtinLayer: BuiltinLayers.regionBackground);
+        layer: coordSpec.layer ?? 0,
+        builtinLayer: BuiltinLayers.regionBackground);
     if (coordSpec is RectCoord) {
       view.add(RectRegionColorRenderOp({
         'region': region,
@@ -123,7 +124,8 @@ void parse<D>(
     }
   } else if (coordSpec.gradient != null) {
     final regionBackgroundScene = view.graffiti.createScene(
-        layer: coordSpec.layer ?? 0, builtinLayer: BuiltinLayers.regionBackground);
+        layer: coordSpec.layer ?? 0,
+        builtinLayer: BuiltinLayers.regionBackground);
     if (coordSpec is RectCoord) {
       view.add(RectRegionGradientRenderOp({
         'region': region,
@@ -566,7 +568,8 @@ void parse<D>(
         final variable =
             annotSpec.variable ?? firstVariables![dim == Dim.x ? 0 : 1];
         final annotScene = view.graffiti.createScene(
-            layer: annotSpec.layer ?? 0, builtinLayer: BuiltinLayers.regionAnnot);
+            layer: annotSpec.layer ?? 0,
+            builtinLayer: BuiltinLayers.regionAnnot);
         view.add(RegionAnnotRenderOp({
           'dim': dim,
           'variable': variable,
@@ -626,7 +629,8 @@ void parse<D>(
         }
 
         final annotScene = view.graffiti.createScene(
-            layer: annotSpec.layer ?? 0, builtinLayer: BuiltinLayers.elementAnnot);
+            layer: annotSpec.layer ?? 0,
+            builtinLayer: BuiltinLayers.elementAnnot);
         view.add(ElementAnnotRenderOp({
           'elements': annot,
           'clip': annotSpec.clip ?? false,


### PR DESCRIPTION
This PR adds keys to all gestures, so the original graph can be identified.