### PR TITLE
reduce repaint

### DIFF
--- a/lib/src/chart/chart.dart
+++ b/lib/src/chart/chart.dart
@@ -240,10 +240,12 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
       child: MouseRegion(
         child: Listener(
           child: GestureDetector(
-            child: CustomPaint(
-              // Make sure the Listener and the GestureDetector inflate the container.
-              size: Size.infinite,
-              painter: _ChartPainter<D>(this),
+            child: RepaintBoundary(
+              child: CustomPaint(
+                // Make sure the Listener and the GestureDetector inflate the container.
+                size: Size.infinite,
+                painter: _ChartPainter<D>(this),
+              ),
             ),
             onDoubleTap: () {
               view!.gesture(Gesture(


### PR DESCRIPTION
使用`RepaintBoundary`可以减少重绘
[example](https://github.com/entronad/graphic/blob/main/example/lib/pages/bigdata.dart)和[相关讨论](https://stackoverflow.com/questions/46702376/how-to-ensure-my-custompaint-widget-painting-is-stored-in-the-raster-cache/46706868#46706868)