### PR TITLE
AttributesGroups deep equality test (speed up selection)

### DIFF
--- a/lib/src/interaction/selection/selection.dart
+++ b/lib/src/interaction/selection/selection.dart
@@ -415,4 +415,12 @@ class SelectionUpdateOp extends Operator<AttributesGroups> {
     }
     return rst;
   }
+
+  ///Need to provide a semantic equality comparison since
+  ///AttributesGroups are really just an alias to a list
+  @override
+  bool equalValue(AttributesGroups a, AttributesGroups b){
+    return deepCollectionEquals(a, b);
+  }
+
 }


### PR DESCRIPTION
The default AttributesGroups equality test is == on a List, which returns false even if the contents are equal.  The impact of this is that Operator.update() will always think the AttributesGroups have changed after a selection, regardless of whether or not there was a real change.

Implementing equal value for AttributesGroups using deepCollectionEquals allows update() to return false when the graph content hasn't changed.  This short-circuits re-rendering as designed.

For a complex graph that uses tooltips but does not change other Attributes on selection, this improves the effective framerate by about 8x.