### PR TITLE
Fix: dart analysis warnings & hints

### DIFF
--- a/example/lib/pages/animation.dart
+++ b/example/lib/pages/animation.dart
@@ -103,7 +103,7 @@ class AnimationPageState extends State<AnimationPage> {
         onPressed: () => setState(() {
           rebuild = true;
         }),
-        child: Icon(Icons.refresh),
+        child: const Icon(Icons.refresh),
       ),
       body: SingleChildScrollView(
         child: Center(
@@ -146,7 +146,7 @@ class AnimationPageState extends State<AnimationPage> {
                   ],
                   marks: [
                     IntervalMark(
-                      transition: Transition(duration: Duration(seconds: 1)),
+                      transition: Transition(duration: const Duration(seconds: 1)),
                       entrance: {MarkEntrance.y},
                       label: LabelEncode(
                           encoder: (tuple) => Label(tuple['sold'].toString())),
@@ -209,7 +209,7 @@ class AnimationPageState extends State<AnimationPage> {
                           variable: 'name', values: Defaults.colors10),
                       elevation: ElevationEncode(value: 5),
                       transition: Transition(
-                          duration: Duration(seconds: 2),
+                          duration: const Duration(seconds: 2),
                           curve: Curves.elasticOut),
                       entrance: {MarkEntrance.y},
                     )
@@ -259,7 +259,7 @@ class AnimationPageState extends State<AnimationPage> {
                         CircleShape(),
                         SquareShape(),
                       ]),
-                      transition: Transition(duration: Duration(seconds: 1)),
+                      transition: Transition(duration: const Duration(seconds: 1)),
                     )
                   ],
                   axes: [
@@ -329,7 +329,7 @@ class AnimationPageState extends State<AnimationPage> {
                       color: ColorEncode(
                           variable: 'genre', values: Defaults.colors10),
                       modifiers: [StackModifier()],
-                      transition: Transition(duration: Duration(seconds: 2)),
+                      transition: Transition(duration: const Duration(seconds: 2)),
                       entrance: {MarkEntrance.y},
                     )
                   ],
@@ -382,7 +382,7 @@ class AnimationPageState extends State<AnimationPage> {
                         Defaults.colors10.first.withAlpha(80),
                         Defaults.colors10.first.withAlpha(10),
                       ])),
-                      transition: Transition(duration: Duration(seconds: 2)),
+                      transition: Transition(duration: const Duration(seconds: 2)),
                       entrance: {
                         MarkEntrance.x,
                         MarkEntrance.y,
@@ -392,7 +392,7 @@ class AnimationPageState extends State<AnimationPage> {
                     LineMark(
                       shape: ShapeEncode(value: BasicLineShape(smooth: true)),
                       size: SizeEncode(value: 0.5),
-                      transition: Transition(duration: Duration(seconds: 2)),
+                      transition: Transition(duration: const Duration(seconds: 2)),
                       entrance: {
                         MarkEntrance.x,
                         MarkEntrance.y,

--- a/example/lib/pages/debug.dart
+++ b/example/lib/pages/debug.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:graphic/graphic.dart';
 
-import '../data.dart';
-
 class DebugPage extends StatelessWidget {
   DebugPage({Key? key}) : super(key: key);
 

--- a/example/lib/pages/debug.dart
+++ b/example/lib/pages/debug.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:graphic/graphic.dart';
 

--- a/example/lib/pages/debug.dart
+++ b/example/lib/pages/debug.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:graphic/graphic.dart';
 
@@ -38,9 +39,9 @@ class DebugPage extends StatelessWidget {
 Widget buildChart(String name, List<Data> data) => Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Container(width: 300, child: Text(name)),
+        SizedBox(width: 300, child: Text(name)),
         const SizedBox(width: 100),
-        Container(
+        SizedBox(
           width: 150,
           height: 150,
           child: Chart(

--- a/example/lib/pages/debug.dart
+++ b/example/lib/pages/debug.dart
@@ -39,7 +39,7 @@ Widget buildChart(String name, List<Data> data) => Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         Container(width: 300, child: Text(name)),
-        SizedBox(width: 100),
+        const SizedBox(width: 100),
         Container(
           width: 150,
           height: 150,

--- a/example/lib/pages/polygon_custom.dart
+++ b/example/lib/pages/polygon_custom.dart
@@ -571,7 +571,7 @@ class PolygonCustomPage extends StatelessWidget {
                                   style: PaintStyle(
                                       fillColor: Defaults.colors10[0]))
                             ],
-                        anchor: (p0) => Offset(0, 0)),
+                        anchor: (p0) => const Offset(0, 0)),
                     TagAnnotation(
                       label: Label(
                         'Email',
@@ -589,7 +589,7 @@ class PolygonCustomPage extends StatelessWidget {
                                   style: PaintStyle(
                                       fillColor: Defaults.colors10[1]))
                             ],
-                        anchor: (p0) => Offset(0, 0)),
+                        anchor: (p0) => const Offset(0, 0)),
                     TagAnnotation(
                       label: Label(
                         'Affiliate',
@@ -607,7 +607,7 @@ class PolygonCustomPage extends StatelessWidget {
                                   style: PaintStyle(
                                       fillColor: Defaults.colors10[2]))
                             ],
-                        anchor: (p0) => Offset(0, 0)),
+                        anchor: (p0) => const Offset(0, 0)),
                     TagAnnotation(
                       label: Label(
                         'Video',
@@ -625,7 +625,7 @@ class PolygonCustomPage extends StatelessWidget {
                                   style: PaintStyle(
                                       fillColor: Defaults.colors10[3]))
                             ],
-                        anchor: (p0) => Offset(0, 0)),
+                        anchor: (p0) => const Offset(0, 0)),
                     TagAnnotation(
                       label: Label(
                         'Direct',
@@ -643,7 +643,7 @@ class PolygonCustomPage extends StatelessWidget {
                                   style: PaintStyle(
                                       fillColor: Defaults.colors10[4]))
                             ],
-                        anchor: (p0) => Offset(0, 0)),
+                        anchor: (p0) => const Offset(0, 0)),
                     TagAnnotation(
                       label: Label(
                         'Search',

--- a/example/lib/pages/polygon_custom.dart
+++ b/example/lib/pages/polygon_custom.dart
@@ -2,7 +2,6 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:graphic/graphic.dart';
-import 'package:graphic/src/graffiti/element/element.dart';
 
 import '../data.dart';
 

--- a/lib/graphic.dart
+++ b/lib/graphic.dart
@@ -178,7 +178,7 @@ export 'src/shape/util/style.dart' show getPaintStyle;
 
 export 'src/graffiti/transition.dart' show Transition;
 export 'src/graffiti/element/element.dart'
-    show MarkElement, PaintStyle, PrimitiveElement, getBlockPaintPoint;
+    show MarkElement, ElementStyle, PaintStyle, PrimitiveElement, getBlockPaintPoint;
 export 'src/graffiti/element/arc.dart' show ArcElement;
 export 'src/graffiti/element/circle.dart' show CircleElement;
 export 'src/graffiti/element/group.dart' show GroupElement;

--- a/lib/src/dataflow/tuple.dart
+++ b/lib/src/dataflow/tuple.dart
@@ -155,7 +155,7 @@ class Attributes {
                 span: rst.label!.style.span,
                 textAlign: rst.label!.style.textAlign,
                 textDirection: rst.label!.style.textDirection,
-                textScaleFactor: rst.label!.style.textScaleFactor,
+                textScaler: rst.label!.style.textScaler,
                 maxLines: rst.label!.style.maxLines,
                 ellipsis: rst.label!.style.ellipsis,
                 locale: rst.label!.style.locale,

--- a/lib/src/graffiti/element/label.dart
+++ b/lib/src/graffiti/element/label.dart
@@ -14,7 +14,7 @@ class LabelStyle extends BlockStyle {
     this.span,
     this.textAlign,
     this.textDirection,
-    this.textScaleFactor,
+    this.textScaler,
     this.maxLines,
     this.ellipsis,
     this.locale,
@@ -68,11 +68,12 @@ class LabelStyle extends BlockStyle {
   /// should be regarded as "default".**
   final TextDirection? textDirection;
 
-  /// The number of font pixels for each logical pixel.
+  /// The font scaling strategy to use when laying out and rendering the text.
   ///
-  /// For example, if the text scale factor is 1.5, text will be 50% larger than
-  /// the specified font size.
-  final double? textScaleFactor;
+  /// The value usually comes from [MediaQuery.textScalerOf],
+  /// which typically reflects the user-specified text scaling value in the platform's accessibility settings.
+  /// The [TextStyle.fontSize] of the text will be adjusted by the [TextScaler] before the text is laid out and rendered.
+  final TextScaler? textScaler;
 
   /// An optional maximum number of lines for the text to span, wrapping if
   /// necessary.
@@ -134,7 +135,7 @@ class LabelStyle extends BlockStyle {
       span: span,
       textAlign: textAlign,
       textDirection: textDirection,
-      textScaleFactor: lerpDouble(from.textScaleFactor, textScaleFactor, t),
+      textScaler: textScaler,
       maxLines: lerpDouble(from.maxLines, maxLines, t)?.toInt(),
       ellipsis: ellipsis,
       locale: locale,
@@ -152,7 +153,7 @@ class LabelStyle extends BlockStyle {
       // span is a function.
       textAlign == other.textAlign &&
       textDirection == other.textDirection &&
-      textScaleFactor == other.textScaleFactor &&
+      textScaler == other.textScaler &&
       maxLines == other.maxLines &&
       ellipsis == other.ellipsis &&
       locale == other.locale &&
@@ -184,7 +185,7 @@ class LabelElement extends BlockElement<LabelStyle> {
           : this.style.span!(text),
       textAlign: this.style.textAlign ?? TextAlign.start,
       textDirection: this.style.textDirection ?? TextDirection.ltr,
-      textScaler: TextScaler.linear(this.style.textScaleFactor ?? 1.0),
+      textScaler: this.style.textScaler ?? TextScaler.noScaling,
       maxLines: this.style.maxLines,
       ellipsis: this.style.ellipsis,
       locale: this.style.locale,

--- a/lib/src/graffiti/element/label.dart
+++ b/lib/src/graffiti/element/label.dart
@@ -184,7 +184,7 @@ class LabelElement extends BlockElement<LabelStyle> {
           : this.style.span!(text),
       textAlign: this.style.textAlign ?? TextAlign.start,
       textDirection: this.style.textDirection ?? TextDirection.ltr,
-      textScaleFactor: this.style.textScaleFactor ?? 1.0,
+      textScaler: TextScaler.linear(this.style.textScaleFactor ?? 1.0),
       maxLines: this.style.maxLines,
       ellipsis: this.style.ellipsis,
       locale: this.style.locale,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 2.2.1
 homepage: https://github.com/entronad/graphic
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
-  flutter: '>=2.6.0'
+  sdk: '>=2.13.0 <4.0.0'
+  flutter: '>=3.16.0'
 
 dependencies:
   collection: ^1.15.0


### PR DESCRIPTION
There are 1 warning and 17 hints in dart analysis.

The PR try to fix them.

<img width="1512" alt="截圖 2024-07-07 晚上7 28 11" src="https://github.com/entronad/graphic/assets/21169170/e377c91d-0978-4f68-b609-da15a08f40f2">

1. remove unused import warning.
2. textScaleFactor was deprecated hint, use TextScaler instead.
3. use 'const' with the constructor to improve performance.
4. use a 'SizedBox' to add whitespace to a layout.
5. the import of 'package:flutter/cupertino.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart'.
6. import of a library in the 'lib/src' directory of another package.
