### PR TITLE
Feature: add labelBackground & labelBackground Mapper for axes.

### DIFF
--- a/lib/src/graffiti/element/label.dart
+++ b/lib/src/graffiti/element/label.dart
@@ -207,6 +207,9 @@ class LabelElement extends BlockElement<LabelStyle> {
   /// The text painter.
   late final TextPainter _painter;
 
+  /// The text size.
+  Size get _textSize => _painter.size;
+
   @override
   void draw(Canvas canvas) => _painter.paint(canvas, paintPoint);
 
@@ -222,4 +225,14 @@ class LabelElement extends BlockElement<LabelStyle> {
   @override
   bool operator ==(Object other) =>
       other is LabelElement && super == other && text == other.text;
+
+  Rect getTextRect() {
+    const horizontalSpacing = 1;
+    final left = paintPoint.dx - horizontalSpacing;
+    final top = paintPoint.dy - 1;
+    final width = _textSize.width + 2 * horizontalSpacing;
+    final height = _textSize.height;
+
+    return Rect.fromLTWH(left, top, width, height);
+  }
 }

--- a/lib/src/guide/axis/axis.dart
+++ b/lib/src/guide/axis/axis.dart
@@ -51,6 +51,11 @@ typedef LabelMapper = LabelStyle? Function(String? text, int index, int total);
 /// [index] and [total] is current and total count of all ticks respectively.
 typedef GridMapper = PaintStyle? Function(String? text, int index, int total);
 
+/// Gets an axis labelBackground style form an axis value text.
+///
+/// [index] and [total] is current and total count of all ticks respectively.
+typedef LabelBackgroundMapper = PaintStyle? Function(String? text, int index, int total);
+
 /// The specification of an axis.
 ///
 /// There can be mutiple axes in one dimension.
@@ -68,11 +73,14 @@ class AxisGuide<V> {
     this.labelMapper,
     this.grid,
     this.gridMapper,
+    this.labelBackground,
+    this.labelBackgroundMapper,
     this.layer,
     this.gridZIndex,
   })  : assert(isSingle([tickLine, tickLineMapper], allowNone: true)),
         assert(isSingle([label, labelMapper], allowNone: true)),
-        assert(isSingle([grid, gridMapper], allowNone: true));
+        assert(isSingle([grid, gridMapper], allowNone: true)),
+        assert(isSingle([labelBackground, labelBackgroundMapper], allowNone: true));
 
   /// The dimension where this axis lies.
   ///
@@ -139,6 +147,18 @@ class AxisGuide<V> {
   /// Only one in [grid] and [gridMapper] can be set.
   GridMapper? gridMapper;
 
+  /// The labelBackground style for all ticks.
+  ///
+  /// Only one in [labelBackground] and [labelBackgroundMapper] can be set.
+  ///
+  /// If null and [labelBackgroundMapper] is also null, there will be no labelBackgrounds.
+  PaintStyle? labelBackground;
+
+  /// Indicates how to get the labelBackground style for each tick.
+  ///
+  /// Only one in [labelBackground] and [labelBackgroundMapper] can be set.
+  LabelBackgroundMapper? labelBackgroundMapper;
+
   /// The layer of this axis.
   ///
   /// If null, a default 0 is set.
@@ -160,6 +180,7 @@ class AxisGuide<V> {
       tickLine == other.tickLine &&
       label == other.label &&
       grid == other.grid &&
+      labelBackground == other.labelBackground &&
       layer == other.layer &&
       gridZIndex == other.gridZIndex;
 }
@@ -186,8 +207,14 @@ class TickInfo {
   /// The stroke style of the tick grid line.
   PaintStyle? grid;
 
+  /// The style of the tick labelBackground.
+  PaintStyle? labelBackground;
+
   /// Whether this tick has a label to render.
   bool get haveLabel => label != null && text != null && text!.isNotEmpty;
+
+  /// Whether this tick has a labelBackground to render.
+  bool get haveLabelBackground => labelBackground != null && text != null && text!.isNotEmpty;
 }
 
 /// The operator to create tick informations.
@@ -206,6 +233,8 @@ class TickInfoOp extends Operator<List<TickInfo>> {
     final labelMapper = params['labelMapper'] as LabelMapper?;
     final grid = params['grid'] as PaintStyle?;
     final gridMapper = params['gridMapper'] as GridMapper?;
+    final labelBackground = params['labelBackground'] as PaintStyle?;
+    final labelBackgroundMapper = params['labelBackgroundMapper'] as LabelBackgroundMapper?;
 
     final scale = scales[variable]!;
 
@@ -233,6 +262,11 @@ class TickInfoOp extends Operator<List<TickInfo>> {
         tick.grid = grid;
       } else if (gridMapper != null) {
         tick.grid = gridMapper(tick.text, i, total);
+      }
+      if (labelBackground != null) {
+        tick.labelBackground = labelBackground;
+      } else if (labelBackgroundMapper != null) {
+        tick.labelBackground = labelBackgroundMapper(tick.text, i, total);
       }
     }
 

--- a/lib/src/guide/axis/circular.dart
+++ b/lib/src/guide/axis/circular.dart
@@ -4,6 +4,7 @@ import 'package:graphic/src/graffiti/element/arc.dart';
 import 'package:graphic/src/graffiti/element/element.dart';
 import 'package:graphic/src/graffiti/element/label.dart';
 import 'package:graphic/src/graffiti/element/line.dart';
+import 'package:graphic/src/graffiti/element/rect.dart';
 import 'package:graphic/src/util/math.dart';
 
 import 'axis.dart';
@@ -50,11 +51,21 @@ List<MarkElement>? renderCircularAxis(
                   : anchorOffset.dy / anchorOffset.dy.abs(),
             ) *
             flipSign;
-        rst.add(LabelElement(
+
+        final lineElement = LabelElement(
             text: tick.text!,
             anchor: labelAnchor,
             defaultAlign: defaultAlign,
-            style: tick.label!));
+            style: tick.label!);
+
+        if (tick.haveLabelBackground) {
+          rst.add(RectElement(
+            rect: lineElement.getTextRect(),
+            style: tick.labelBackground!,
+          ));
+        }
+
+        rst.add(lineElement);
       }
     }
   }

--- a/lib/src/guide/axis/horizontal.dart
+++ b/lib/src/guide/axis/horizontal.dart
@@ -3,6 +3,7 @@ import 'package:graphic/src/coord/rect.dart';
 import 'package:graphic/src/graffiti/element/element.dart';
 import 'package:graphic/src/graffiti/element/label.dart';
 import 'package:graphic/src/graffiti/element/line.dart';
+import 'package:graphic/src/graffiti/element/rect.dart';
 
 import 'axis.dart';
 
@@ -39,11 +40,20 @@ List<MarkElement>? renderHorizontalAxis(
             style: tick.tickLine!.style));
       }
       if (tick.haveLabel) {
-        rst.add(LabelElement(
+        final lineElement = LabelElement(
             text: tick.text!,
             anchor: Offset(x, y),
             defaultAlign: flip ? Alignment.topCenter : Alignment.bottomCenter,
-            style: tick.label!));
+            style: tick.label!);
+
+        if (tick.haveLabelBackground) {
+          rst.add(RectElement(
+            rect: lineElement.getTextRect(),
+            style: tick.labelBackground!,
+          ));
+        }
+
+        rst.add(lineElement);
       }
     }
   }

--- a/lib/src/guide/axis/radial.dart
+++ b/lib/src/guide/axis/radial.dart
@@ -4,6 +4,7 @@ import 'package:graphic/src/graffiti/element/arc.dart';
 import 'package:graphic/src/graffiti/element/element.dart';
 import 'package:graphic/src/graffiti/element/label.dart';
 import 'package:graphic/src/graffiti/element/line.dart';
+import 'package:graphic/src/graffiti/element/rect.dart';
 import 'package:graphic/src/util/math.dart';
 
 import 'axis.dart';
@@ -91,11 +92,20 @@ List<MarkElement>? renderRadialAxis(
   final labelAlign = radialLabelAlign(featureOffset) * flipSign;
   for (var index in labelAnchors.keys) {
     final tick = ticks[index];
-    rst.add(LabelElement(
+    final lineElement = LabelElement(
         text: tick.text!,
         anchor: labelAnchors[index]!,
         defaultAlign: labelAlign,
-        style: tick.label!));
+        style: tick.label!);
+
+    if (tick.haveLabelBackground) {
+      rst.add(RectElement(
+        rect: lineElement.getTextRect(),
+        style: tick.labelBackground!,
+      ));
+    }
+
+    rst.add(lineElement);
   }
 
   return rst.isEmpty ? null : rst;

--- a/lib/src/guide/axis/vertical.dart
+++ b/lib/src/guide/axis/vertical.dart
@@ -3,6 +3,7 @@ import 'package:graphic/src/coord/rect.dart';
 import 'package:graphic/src/graffiti/element/element.dart';
 import 'package:graphic/src/graffiti/element/label.dart';
 import 'package:graphic/src/graffiti/element/line.dart';
+import 'package:graphic/src/graffiti/element/rect.dart';
 
 import 'axis.dart';
 
@@ -39,11 +40,20 @@ List<MarkElement>? renderVerticalAxis(
             style: tick.tickLine!.style));
       }
       if (tick.haveLabel) {
-        rst.add(LabelElement(
+        final lineElement = LabelElement(
             text: tick.text!,
             anchor: Offset(x, y),
             defaultAlign: flip ? Alignment.centerRight : Alignment.centerLeft,
-            style: tick.label!));
+            style: tick.label!);
+
+        if (tick.haveLabelBackground) {
+          rst.add(RectElement(
+            rect: lineElement.getTextRect(),
+            style: tick.labelBackground!,
+          ));
+        }
+
+        rst.add(lineElement);
       }
     }
   }

--- a/lib/src/parse/parse.dart
+++ b/lib/src/parse/parse.dart
@@ -538,6 +538,8 @@ void parse<D>(
         'labelMapper': axisSpec.labelMapper,
         'grid': axisSpec.grid,
         'gridMapper': axisSpec.gridMapper,
+        'labelBackground': axisSpec.labelBackground,
+        'labelBackgroundMapper': axisSpec.labelBackgroundMapper,
       }));
 
       final axisScene = view.graffiti.createScene(


### PR DESCRIPTION
## Description

Sometimes we need a rectangle background for axis label. For example, in a realtime stock trend chart, highlight the upper and lower limit price:

![Screenshot_20240708_121321](https://github.com/entronad/graphic/assets/21169170/955079f3-d42f-4356-96b4-3c95f33cb5af)

Example code:

```dart
Defaults.verticalAxis
  ..labelBackgroundMapper = (text, i , total) {
    if (i == 1) return PaintStyle(fillColor: Colors.green);
    if (i == total-2) return PaintStyle(fillColor: Colors.red);
    return null;
  }
```

## Snapshots on other axis

![Screenshot_20240708_121341](https://github.com/entronad/graphic/assets/21169170/84ba1cce-0e82-4b39-8dd6-0c17c3d51b6e)
![Screenshot_20240708_121431](https://github.com/entronad/graphic/assets/21169170/b5b42d75-5e6f-4be0-b707-5dc752a43120)
