### PR TITLE
Feature: expand crosshair on edges

### DIFF
--- a/lib/graphic.dart
+++ b/lib/graphic.dart
@@ -212,7 +212,13 @@ export 'src/coord/polar.dart' show PolarCoord, PolarCoordConv;
 export 'src/coord/rect.dart' show RectCoord, RectCoordConv;
 
 export 'src/guide/axis/axis.dart'
-    show TickLine, TickLineMapper, LabelMapper, GridMapper, AxisGuide;
+    show
+        TickLine,
+        TickLineMapper,
+        LabelMapper,
+        LabelBackgroundMapper,
+        GridMapper,
+        AxisGuide;
 export 'src/guide/interaction/tooltip.dart' show TooltipGuide, TooltipRenderer;
 export 'src/guide/interaction/crosshair.dart' show CrosshairGuide;
 export 'src/guide/annotation/annotation.dart' show Annotation;

--- a/lib/src/parse/parse.dart
+++ b/lib/src/parse/parse.dart
@@ -102,10 +102,12 @@ void parse<D>(
 
   final coordSpec = spec.coord ?? RectCoord();
 
+  final regionPadding = spec.padding ??
+      (coordSpec is RectCoord ? _defaultRectPadding : _defaultPolarPadding);
+
   final region = view.add(RegionOp({
     'size': size,
-    'padding': spec.padding ??
-        (coordSpec is RectCoord ? _defaultRectPadding : _defaultPolarPadding),
+    'padding': regionPadding,
   }));
 
   if (coordSpec.color != null) {
@@ -685,6 +687,9 @@ void parse<D>(
       'showLabel': showLabel,
       'followPointer': crosshairSpec.followPointer ?? [false, false],
       'scales': scales,
+      'size': size,
+      'padding': regionPadding,
+      'expandEdges': crosshairSpec.expandEdges ?? [false, false, false, false],
     }, crosshairScene, view));
   }
 


### PR DESCRIPTION
## Description

When we like to join two chart with crosshair move together, the join side padding must be zero, otherwise crosshair will be cut like image below:

![cutted_crosshair](https://github.com/user-attachments/assets/cba8a942-0a9d-40f1-a665-f03148907149)

ps. By adding 50 px bottom padding on top chart.

## Solution

By adding `List<bool> expandEdges`, we can decide crosshair expand on left, top, right and bottom  directions respectively. Default value is [false, false, false, false]. And only work on `RectCoord`. - de0a30bbe553c2b362f4e06d49ebd6ca0e02c046

if we add line like this in top chart, we get no-cut crosshair:

```dart
  crosshair: CrosshairGuide(
     ...
     expandEdges: [false, false, false, true],
  ),
```

![expanded_crosshair](https://github.com/user-attachments/assets/baa48922-2561-4452-b2ec-a0c126b35447)

Additional fix for show `LabelBackgroundMapper` - 1857d1812115ae6d7cce44f1bfc1cb4b129f3e18
