### PR TITLE
Feature: custom crosshair labels formatter

### DIFF
--- a/lib/src/guide/interaction/crosshair.dart
+++ b/lib/src/guide/interaction/crosshair.dart
@@ -30,6 +30,7 @@ class CrosshairGuide {
     this.labelStyles,
     this.labelBackgroundStyles,
     this.showLabel,
+    this.formatter,
     this.followPointer,
     this.layer,
     this.mark,
@@ -61,6 +62,11 @@ class CrosshairGuide {
   ///
   /// If null, a default `[false, false]` is set.
   List<bool>? showLabel;
+
+  /// Convert the value to a [String] on the chart.
+  ///
+  /// If null, a default [Scale.format, Scale.format] is used.
+  List<String? Function(dynamic)?>? formatter;
 
   /// Whether the position for each dimension follows the pointer or stick to selected
   /// points.
@@ -127,6 +133,7 @@ class CrosshairRenderOp extends Render {
     final labelBackgroundStyles =
         params['labelBackgroundStyles'] as List<PaintStyle?>;
     final showLabel = params['showLabel'] as List<bool>;
+    final formatter = params['formatter'] as List<String? Function(dynamic)?>;
     final followPointer = params['followPointer'] as List<bool>;
     final scales = params['scales'] as Map<String, ScaleConv>;
     final size = params['size'] as Size;
@@ -211,7 +218,9 @@ class CrosshairRenderOp extends Render {
           final fieldX = coord.transposed ? fields[1] : fields[0];
           final scaleX = scales[fieldX];
           final denormalize = scaleX?.denormalize(cross.dx) ?? -1;
-          final text = scaleX?.format(scaleX.invert(denormalize)) ?? '';
+          final invert = scaleX?.invert(denormalize);
+          final text =
+              formatter[0]?.call(invert) ?? scaleX?.format(invert) ?? '';
           final rect = _getLabelBlock(text: text, style: labelStyleX);
 
           double posX = canvasCrossX;
@@ -258,7 +267,9 @@ class CrosshairRenderOp extends Render {
           final fieldY = coord.transposed ? fields[0] : fields[1];
           final scaleY = scales[fieldY];
           final denormalize = scaleY?.denormalize(cross.dy) ?? -1;
-          final text = scaleY?.format(scaleY.invert(denormalize)) ?? '';
+          final invert = scaleY?.invert(denormalize);
+          final text =
+              formatter[1]?.call(invert) ?? scaleY?.format(invert) ?? '';
           final rect = _getLabelBlock(text: text, style: labelStyleY);
 
           double posY = canvasCrossY;
@@ -299,7 +310,8 @@ class CrosshairRenderOp extends Render {
         if (showLabel[0] && labelStyleX != null) {
           final fieldX = coord.transposed ? fields[2] : fields[0];
           final scaleX = scales[fieldX];
-          final text = scaleX?.format(tuple[fieldX]) ?? '';
+          final value = tuple[fieldX];
+          final text = formatter[0]?.call(value) ?? scaleX?.format(value) ?? '';
           final diagonal = _getLabelDiagonal(text: text, style: labelStyleX);
 
           final label = LabelElement(
@@ -333,8 +345,9 @@ class CrosshairRenderOp extends Render {
           final fieldY = coord.transposed ? fields[0] : fields[2];
           final scaleY = scales[fieldY];
           final denormalize = scaleY?.denormalize(abstractRadius) ?? 0;
-          final value = scaleY?.invert(denormalize);
-          final text = scaleY?.format(value) ?? '';
+          final invert = scaleY?.invert(denormalize);
+          final text =
+              formatter[0]?.call(invert) ?? scaleY?.format(value) ?? '';
           final rect = _getLabelBlock(text: text, style: labelStyleY);
 
           final label = LabelElement(

--- a/lib/src/guide/interaction/crosshair.dart
+++ b/lib/src/guide/interaction/crosshair.dart
@@ -210,7 +210,8 @@ class CrosshairRenderOp extends Render {
         if (showLabel[0] && !canvasCross.dx.isNaN && labelStyleX != null) {
           final fieldX = coord.transposed ? fields[1] : fields[0];
           final scaleX = scales[fieldX];
-          final text = scaleX?.format(scaleX.invert(cross.dx)) ?? '';
+          final denormalize = scaleX?.denormalize(cross.dx) ?? -1;
+          final text = scaleX?.format(scaleX.invert(denormalize)) ?? '';
           final rect = _getLabelBlock(text: text, style: labelStyleX);
 
           double posX = canvasCrossX;
@@ -256,7 +257,8 @@ class CrosshairRenderOp extends Render {
         if (showLabel[1] && !canvasCross.dy.isNaN && labelStyleY != null) {
           final fieldY = coord.transposed ? fields[0] : fields[1];
           final scaleY = scales[fieldY];
-          final text = scaleY?.format(scaleY.invert(cross.dy)) ?? '';
+          final denormalize = scaleY?.denormalize(cross.dy) ?? -1;
+          final text = scaleY?.format(scaleY.invert(denormalize)) ?? '';
           final rect = _getLabelBlock(text: text, style: labelStyleY);
 
           double posY = canvasCrossY;
@@ -330,7 +332,8 @@ class CrosshairRenderOp extends Render {
         if (showLabel[1] && labelStyleY != null) {
           final fieldY = coord.transposed ? fields[0] : fields[2];
           final scaleY = scales[fieldY];
-          final value = scaleY?.invert(abstractRadius);
+          final denormalize = scaleY?.denormalize(abstractRadius) ?? 0;
+          final value = scaleY?.invert(denormalize);
           final text = scaleY?.format(value) ?? '';
           final rect = _getLabelBlock(text: text, style: labelStyleY);
 

--- a/lib/src/parse/parse.dart
+++ b/lib/src/parse/parse.dart
@@ -685,6 +685,7 @@ void parse<D>(
             PaintStyle(fillColor: const Color(0xff000000)),
           ],
       'showLabel': showLabel,
+      'formatter': crosshairSpec.formatter ?? [null, null],
       'followPointer': crosshairSpec.followPointer ?? [false, false],
       'scales': scales,
       'size': size,


### PR DESCRIPTION
## Description

Current crosshair labels' format is followed by scale's formatter. The PR is try to give custom formatter for crosshair labels.

At first, fix the label value.(should denormalize value before invert) - 6a8b10a884b438bfb45a5351079e4eb2bd0f9c2c

And Then add the `formatter` property - 326511c210eb4541dd6a27e881e85c5f2407ff59

For example,

**Original format**

![original_format](https://github.com/user-attachments/assets/bda145ef-7e46-4ab5-9087-b36d1e21e22b)


**Custom format**

```dart
                   crosshair: CrosshairGuide(
                     ...
                     formatter: [
                       (date) => DateFormat('MM/dd').format(DateTime.parse(date as String)),
                       (volume) => (volume as num).toStringAsFixed(0),
                     ],
                   ),
```

![custom_format](https://github.com/user-attachments/assets/dc854476-1919-4e6d-851b-aaa4f10c02c5)

