### PR TITLE
Feat: add one point support for LineMark

### DIFF
--- a/lib/src/graffiti/element/polyline.dart
+++ b/lib/src/graffiti/element/polyline.dart
@@ -37,7 +37,7 @@ class PolylineElement extends PrimitiveElement {
     double? rotation,
     Offset? rotationAxis,
     String? tag,
-  })  : assert(points.length >= 2),
+  })  : assert(points.isNotEmpty),
         super(
           style: style,
           rotation: rotation,

--- a/lib/src/shape/line.dart
+++ b/lib/src/shape/line.dart
@@ -105,11 +105,15 @@ class BasicLineShape extends LineShape {
     final primitives = <MarkElement>[];
 
     final represent = group.first;
-    final style = getPaintStyle(
-        represent, true, represent.size ?? defaultSize, coord.region, dash);
+    final strokeWidth = represent.size ?? defaultSize;
+    final style =
+        getPaintStyle(represent, true, strokeWidth, coord.region, dash);
 
     for (var contour in contours) {
-      if (smooth) {
+      if (contour.length == 1) {
+        primitives.add(CircleElement(
+            center: contour[0], radius: strokeWidth / 2, style: style));
+      } else if (smooth) {
         primitives.add(SplineElement(
             start: contour.first,
             cubics: getCubicControls(contour, false, true),


### PR DESCRIPTION
## Description

Sometime we need to display one point on LineMark chart. For example, a realtime stock trend chart, which only one point when market just started.

## Architecture

If there is only one point, draw the `CircleElement` instead, and the radius of circle is the half of strokeWidth.

**Demo:**

![one_point](https://github.com/user-attachments/assets/1f90b6d2-4c9d-4f6d-a631-ee2b90bdd503)

