### PR TITLE
Fix: CustomAnnotation `==` logic

### DIFF
--- a/lib/src/guide/annotation/custom.dart
+++ b/lib/src/guide/annotation/custom.dart
@@ -27,7 +27,8 @@ class CustomAnnotation extends ElementAnnotation {
   List<MarkElement> Function(Offset, Size) renderer;
 
   @override
-  bool operator ==(Object other) => other is CustomAnnotation && super == other;
+  bool operator ==(Object other) =>
+      other is CustomAnnotation && super == other && values == other.values;
 }
 
 /// The custom element annotation operator.


### PR DESCRIPTION
## Description

By adding a `CustomAnnotation` circle at the last interval mark, when data growing the circle position would not change.

## Solution

Add compare values data:

```dart
   @override
   bool operator ==(Object other) =>
      other is CustomAnnotation && super == other && values == other.values;

```

## Test

**As is:**

[As is.webm](https://github.com/user-attachments/assets/6e1b048a-a5e8-40b9-8e4d-635fe38c5392)

**To be:**

[To be.webm](https://github.com/user-attachments/assets/9cdc63a0-ec8c-4bcf-a171-af4077cd2ed6)

**Demo Sample Code:**

CustomAnnotation:

```dart
                  annotations: [
                    CustomAnnotation(
                      renderer: (offset, size) =>
                          [CircleElement(center: offset, radius: 8, style: PaintStyle(fillColor: Colors.green))],
                      values: [data.last['genre'], data.last['sold']],
                    ),
                  ],
```

Adding new data after 5s:

```dart
    data = [
      {'genre': 'Sports', 'sold': rdm.nextInt(300)},
    ];

    int index = 1;

    timer = Timer.periodic(const Duration(seconds: 1), (_) {
      setState(() {
        if (index >= 5) {
          data.last = ({'genre': 'Other_4', 'sold': rdm.nextInt(300)});
          data = List.of(data);
          return;
        }

        data.add({'genre': 'Other_${index}', 'sold': rdm.nextInt(300)});
        data = List.from(data);
        index += 1;
      });
    });
```