### PR TITLE
Mounted check before repaint setState 

### DIFF
--- a/lib/src/chart/chart.dart
+++ b/lib/src/chart/chart.dart
@@ -216,7 +216,9 @@ class ChartState<D> extends State<Chart<D>> with TickerProviderStateMixin {
 
   /// Asks the chart state to trigger a repaint.
   void repaint() {
-    setState(() {});
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,4 +24,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^4.0.0
+  flutter_lints: ^6.0.0


### PR DESCRIPTION
Adding a mounted check for the Chart widget repaint method, as it's possible for the repaint method to be calling setState while the widget has been disposed.